### PR TITLE
Space between logos/flags and text

### DIFF
--- a/airline-web/public/javascripts/airline.js
+++ b/airline-web/public/javascripts/airline.js
@@ -20,9 +20,9 @@ function updateAirlineInfo(airlineId) {
 	    	refreshTopBar(airline)
 	    	$("#currentAirline").text(airline.name)
 	    	if (airline.headquarterAirport) {
-	    		$("#currentAirlineCountry").html("<img src='assets/images/flags/" + airline.headquarterAirport.countryCode + ".png' />")
+                        $("#currentAirlineCountry").html("<img class='flag' src='assets/images/flags/" + airline.headquarterAirport.countryCode + ".png' />")
 	    	} else {
-	    		$("#currentAirlineCountry").empty()
+                        $("#currentAirlineCountry").empty()
 	    	}
 	    	activeAirline = airline
 	    	updateLinksInfo()
@@ -1761,4 +1761,4 @@ function updateLoadedLinks(links) {
 	});
 }
 
-	
+

--- a/airline-web/public/javascripts/airport.js
+++ b/airline-web/public/javascripts/airport.js
@@ -445,7 +445,7 @@ function addCityMarkers(airportMap, airport) {
 			  $("#cityPopupPopulation").text(city.population)
 			  $("#cityPopupIncomeLevel").text(city.incomeLevel)
 			  $("#cityPopupCountryCode").text(city.countryCode)
-			  $("#cityPopupCountryCode").append("<img src='assets/images/flags/" + city.countryCode + ".png' />")
+			  $("#cityPopupCountryCode").append("<img class='flag' src='assets/images/flags/" + city.countryCode + ".png' />")
 			  $("#cityPopupId").val(city.id)
 			   
 			  

--- a/airline-web/public/javascripts/country.js
+++ b/airline-web/public/javascripts/country.js
@@ -136,7 +136,7 @@ function loadCountryDetails(countryId) {
 	    		var championDivs = ""
 	    			
     			$.each(country.champions, function(index, champion) {
-    				championDivs += "<div>" + getRankingImg(champion.ranking) + getAirlineLogoImg(champion.airline.id) + "&nbsp;<span style='font-weight: bold;'>" + champion.airline.name + "</span> (" + champion.passengerCount + " passengers, " + champion.reputationBoost + " reputation bonus)</div>"
+    				championDivs += "<div>" + getRankingImg(champion.ranking) + getAirlineLogoImg(champion.airline.id) + "<span style='font-weight: bold;'>" + champion.airline.name + "</span> (" + champion.passengerCount + " passengers, " + champion.reputationBoost + " reputation bonus)</div>"
     			})
 	    		
 	    		$("#countryDetailsChampion").html(championDivs)

--- a/airline-web/public/javascripts/gadgets.js
+++ b/airline-web/public/javascripts/gadgets.js
@@ -162,7 +162,7 @@ function getCountryFlagImg(countryCode) {
 		var countryFlagUrl = getCountryFlagUrl(countryCode);
 		var countryName = loadedCountriesByCode[countryCode].name
 		if (countryFlagUrl) {
-			return "<img src='" + countryFlagUrl + "' title='" + countryName +"'/>"
+			return "<img class='flag' src='" + countryFlagUrl + "' title='" + countryName +"'/>"
 		} else {
 			return ""
 		}

--- a/airline-web/public/stylesheets/main.css
+++ b/airline-web/public/stylesheets/main.css
@@ -302,7 +302,7 @@ li.row, div.table-row {
 }
 
 .table.data .table-row div {
-	padding: 3px 0px;
+	padding: 3px;
 }
 
 .warning, .fatal {

--- a/airline-web/public/stylesheets/main.css
+++ b/airline-web/public/stylesheets/main.css
@@ -404,6 +404,7 @@ div#canvas {
 
 img.logo {
     box-shadow: 0 0 2px 1px rgba(255, 255, 255, 0.2);
+    margin-right: 3px;
 }
 
 .airlineColorDot {

--- a/airline-web/public/stylesheets/main.css
+++ b/airline-web/public/stylesheets/main.css
@@ -403,11 +403,11 @@ div#canvas {
 }
 
 img.logo {
-	box-shadow: 0 0 2px 1px rgba(255, 255, 255, 0.2);
+    box-shadow: 0 0 2px 1px rgba(255, 255, 255, 0.2);
 }
 
 .airlineColorDot {
-	width:          15px;
+    width:          15px;
     height:         15px;
     padding:        1px;
     border:         1px solid #ccc;

--- a/airline-web/public/stylesheets/main.css
+++ b/airline-web/public/stylesheets/main.css
@@ -407,6 +407,10 @@ img.logo {
     margin-right: 3px;
 }
 
+img.flag {
+    margin-right: 3px;
+}
+
 .airlineColorDot {
     width:          15px;
     height:         15px;


### PR DESCRIPTION
It was bugging me that the logos and flags were smashed against the text. This changes all the ones I found except the country list. That page draws them in separate cells and the code looks to nice to go messing with just to make things match.