### PR TITLE
Update FlightPreference.scala

### DIFF
--- a/airline-data/src/main/scala/com/patson/model/FlightPreference.scala
+++ b/airline-data/src/main/scala/com/patson/model/FlightPreference.scala
@@ -84,7 +84,7 @@ case class AppealPreference(appealList : Map[Int, AirlineAppeal], linkClass : Li
         // Wants a lounge .. SHOULD NOT NEED THEM ON BOTH SIDES as that is impractical
         // But if they are there .. slight extra bonus
         
-        if ((fromLoungeLevel >= loungeLevelRequired) || (toLoungeLevel < loungeLevelRequired)) {
+        if ((fromLoungeLevel >= loungeLevelRequired) || (toLoungeLevel >= loungeLevelRequired)) {
          // Atleast one side has the lounge .. nice 
           perceivedPrice = perceivedPrice - AppealPreference.LOUNGE_PERCEIVED_PRICE_REDUCTION_BASE * (fromLoungeLevel.max(toLoungeLevel) * linkClass.priceMultiplier).toInt
         }


### PR DESCRIPTION
So .. few suggestions to test

#1 Old Logic made it so you needed lounges on both sides for those lounge wanting customers to actually utilize that link (penalty for one-sided lounge was huge). In reality we can only build lounges in certain hubs so rarely should we have both sides. 

#2 For non-lounge business/first customers the existence of a lounge skewed demand way too much towards airlines with a lounge. Barely anyone would utilize links without lounge if alternative link had one