### PR TITLE
Update OilSource.scala

### DIFF
--- a/airline-data/src/main/scala/com/patson/data/OilSource.scala
+++ b/airline-data/src/main/scala/com/patson/data/OilSource.scala
@@ -140,9 +140,14 @@ object OilSource {
   
   def loadOilPriceByCycle(cycle : Int) : Option[OilPrice] = {
     var queryString = "SELECT * FROM " + OIL_PRICE_TABLE + " WHERE cycle = ?"
-    val result = loadOilPricesByQueryString(queryString, List(cycle))
+    var result = loadOilPricesByQueryString(queryString, List(cycle))
     if (result.isEmpty) {
-      None
+      result = loadOilPricesByQueryString(queryString, List(cycle-1))
+      if (result.isEmpty) {
+        None
+      } else {
+        Some(result(0))
+      }
     } else {
       Some(result(0))
     }


### PR DESCRIPTION
So found this bug on my retro server. It only shows up when the actual cycle sim time is less than the scheduled time. Main sim runs the cycle then increments the week. This causes the current oil prices (for contracts, etc) not be able to load (and then defaults to 70) as it's requesting "NEXT WEEK" if you check prices during the time the simulator has finished with the last week but hasn't started the next week.

Of course you could just change the order of the main sim actor so it increments first then triggers start cycle, but due to consistency concerns I did it this way.