### PR TITLE
Flight preference adjustments

### DIFF
--- a/airline-data/src/main/scala/com/patson/PassengerSimulation.scala
+++ b/airline-data/src/main/scala/com/patson/PassengerSimulation.scala
@@ -60,7 +60,7 @@ object PassengerSimulation {
         case (_, soldSeats) => soldSeats 
       }
       
-    soldLinks.foreach{ case(link, soldSeats) => println(link.airline.name + "($" + link.price + "; recommend $" + Pricing.computeStandardPrice(link, ECONOMY) + ") " + soldSeats  + " : " + link.from.name + " => " + link.to.name) }
+    soldLinks.foreach{ case(link, soldSeats) => println(link.airline.name + "($" + link.price + "; recommend $" + link.standardPrice(ECONOMY) + ") " + soldSeats  + " : " + link.from.name + " => " + link.to.name) }
     println("seats sold: " + soldLinks.foldLeft(0) {
       case (holder, (link, soldSeats)) => holder + soldSeats
     })
@@ -545,7 +545,7 @@ object PassengerSimulation {
                 connectionCost += 50 
               }
               
-              connectionCost *= passengerGroup.preference.connectionCostRatio
+              connectionCost *= passengerGroup.preference.connectionCostRatio * passengerGroup.preference.preferredLinkClass.priceMultiplier //connection cost should take into consideration of preferred link class too
           }
           
           

--- a/airline-data/src/main/scala/com/patson/PassengerSimulation.scala
+++ b/airline-data/src/main/scala/com/patson/PassengerSimulation.scala
@@ -542,7 +542,7 @@ object PassengerSimulation {
               val previousLinkAirlineId = predecessorLink.airline.id
               val currentLinkAirlineId = linkConsideration.link.airline.id
               if (previousLinkAirlineId != currentLinkAirlineId && (allianceIdByAirlineId.get(previousLinkAirlineId) == None || allianceIdByAirlineId.get(previousLinkAirlineId) != allianceIdByAirlineId.get(currentLinkAirlineId))) { //switch airline, impose extra cost
-                connectionCost += 50 
+                connectionCost += 100
               }
               
               connectionCost *= passengerGroup.preference.connectionCostRatio * passengerGroup.preference.preferredLinkClass.priceMultiplier //connection cost should take into consideration of preferred link class too

--- a/airline-data/src/main/scala/com/patson/init/AiPricePatcher.scala
+++ b/airline-data/src/main/scala/com/patson/init/AiPricePatcher.scala
@@ -36,7 +36,7 @@ object AiPricePatcher extends App {
     val updatingLinks = ListBuffer[Link]()
     AirlineSource.loadAllAirlines(false).filter(_.isGenerated).foreach {  aiAirline =>
       LinkSource.loadLinksByAirlineId(aiAirline.id).foreach { link =>
-        updatingLinks += link.copy(price = LinkClassValues.getInstance(Pricing.computeStandardPrice(link, ECONOMY), 0, 0))
+        updatingLinks += link.copy(price = LinkClassValues.getInstance(link.standardPrice(ECONOMY), 0, 0))
       }
     }
     

--- a/airline-data/src/main/scala/com/patson/model/Airport.scala
+++ b/airline-data/src/main/scala/com/patson/model/Airport.scala
@@ -415,13 +415,13 @@ object Airport {
   
   import FlightType._
   val qualityExpectationFlightTypeAdjust = 
-  Map(SHORT_HAUL_DOMESTIC -> LinkClassValues.getInstance(-15, 0, 15),
-        SHORT_HAUL_INTERNATIONAL ->  LinkClassValues.getInstance(-10, 5, 20),
-        SHORT_HAUL_INTERCONTINENTAL -> LinkClassValues.getInstance(-5, 10, 25),
-        LONG_HAUL_DOMESTIC -> LinkClassValues.getInstance(0, 15, 30),
-        LONG_HAUL_INTERNATIONAL -> LinkClassValues.getInstance(5, 20, 35),
-        LONG_HAUL_INTERCONTINENTAL -> LinkClassValues.getInstance(10, 25, 40),
-        ULTRA_LONG_HAUL_INTERCONTINENTAL -> LinkClassValues.getInstance(10, 25, 40))
+  Map(SHORT_HAUL_DOMESTIC -> LinkClassValues.getInstance(-15, -5, 5),
+        SHORT_HAUL_INTERNATIONAL ->  LinkClassValues.getInstance(-10, 0, 10),
+        SHORT_HAUL_INTERCONTINENTAL -> LinkClassValues.getInstance(-5, 5, 15),
+        LONG_HAUL_DOMESTIC -> LinkClassValues.getInstance(0, 5, 15),
+        LONG_HAUL_INTERNATIONAL -> LinkClassValues.getInstance(5, 10, 20),
+        LONG_HAUL_INTERCONTINENTAL -> LinkClassValues.getInstance(10, 15, 20),
+        ULTRA_LONG_HAUL_INTERCONTINENTAL -> LinkClassValues.getInstance(10, 15, 20))
 }
 
 case class Runway(length : Int, runwayType : RunwayType.Value)

--- a/airline-data/src/main/scala/com/patson/model/FlightPreference.scala
+++ b/airline-data/src/main/scala/com/patson/model/FlightPreference.scala
@@ -161,13 +161,13 @@ case class AppealPreference(homeAirport : Airport, preferredLinkClass : LinkClas
     
     var perceivedPrice = link.price(linkClass);
     if (linkClass.level != preferredLinkClass.level) {
-      perceivedPrice = (perceivedPrice / linkClass.priceMultiplier * preferredLinkClass.priceMultiplier * 2).toInt //have to normalize the price to match the preferred link class, * 2 for unwillingness to downgrade
+      perceivedPrice = (perceivedPrice / linkClass.priceMultiplier * preferredLinkClass.priceMultiplier * 2.5).toInt //have to normalize the price to match the preferred link class, * 2.5 for unwillingness to downgrade
     }
 
-    val standardPrice = link.standardPrice(linkClass)
+    val standardPrice = link.standardPrice(preferredLinkClass)
     val deltaFromStandardPrice = perceivedPrice - standardPrice
 
-    perceivedPrice = (standardPrice + deltaFromStandardPrice * linkClass.priceSensitivity).toInt
+    perceivedPrice = (standardPrice + deltaFromStandardPrice * preferredLinkClass.priceSensitivity).toInt
     
     val loyalty = appeal.loyalty
     //the maxReduceFactorForThisAirline, if at max loyalty, it is the same as maxReduceFactorAtMaxLoyalty, at 0 loyalty, this is at maxReduceFactorAtMinLoyalty
@@ -200,7 +200,7 @@ case class AppealPreference(homeAirport : Airport, preferredLinkClass : LinkClas
     //println(link.airline.name + " loyalty " + loyalty + " from price " + link.price + " reduced to " + perceivedPrice)
     
     //adjust by lounge
-    if (linkClass.level >= BUSINESS.level) {
+    if (preferredLinkClass.level >= BUSINESS.level) {
       val fromLounge = link.from.getLounge(link.airline.id, link.airline.getAllianceId, activeOnly = true)
       val toLounge = link.to.getLounge(link.airline.id, link.airline.getAllianceId, activeOnly = true)
         

--- a/airline-data/src/main/scala/com/patson/model/Link.scala
+++ b/airline-data/src/main/scala/com/patson/model/Link.scala
@@ -170,10 +170,10 @@ case class LinkConsideration(link : Link, cost : Double, linkClass : LinkClass, 
 sealed abstract class LinkClass(val code : String, val spaceMultiplier : Double, val resourceMultiplier : Double, val priceMultiplier : Double, val priceSensitivity : Double, val level : Int) {
   def label : String //level for sorting/comparison purpose
 }
-case object FIRST extends LinkClass("F", spaceMultiplier = 6, resourceMultiplier = 3, priceMultiplier = 9, priceSensitivity = 0.4, level = 3) {
+case object FIRST extends LinkClass("F", spaceMultiplier = 6, resourceMultiplier = 3, priceMultiplier = 9, priceSensitivity = 0.6, level = 3) {
   override def label = "first"
 }
-case object BUSINESS extends LinkClass("J", spaceMultiplier = 2.5, resourceMultiplier = 2, priceMultiplier = 3, priceSensitivity = 0.7, level = 2) {
+case object BUSINESS extends LinkClass("J", spaceMultiplier = 2.5, resourceMultiplier = 2, priceMultiplier = 3, priceSensitivity = 0.8, level = 2) {
   override def label = "business"
 }
 case object ECONOMY extends LinkClass("Y", spaceMultiplier = 1, resourceMultiplier = 1, priceMultiplier = 1, priceSensitivity = 1.0, level =1) {

--- a/airline-data/src/main/scala/com/patson/model/Link.scala
+++ b/airline-data/src/main/scala/com/patson/model/Link.scala
@@ -22,7 +22,9 @@ case class Link(from : Airport, to : Airport, airline: Airline, price : LinkClas
   @volatile private var hasComputedQuality = false
   @volatile private var computedQualityStore : Int = 0
   @volatile private var computedQualityPriceAdjust : ConcurrentHashMap[LinkClass, Double] = new ConcurrentHashMap[LinkClass, Double]()
-  
+
+  private val standardPrice : ConcurrentHashMap[LinkClass, Int] = new ConcurrentHashMap[LinkClass, Int]()
+
   def setAssignedAirplanes(assignedAirplanes : List[Airplane]) = {
     this.assignedAirplanes = assignedAirplanes
     if (!assignedAirplanes.isEmpty) {
@@ -118,6 +120,13 @@ case class Link(from : Airport, to : Airport, airline: Airline, price : LinkClas
       LinkClassValues.getInstance()
     }
   }
+
+  def standardPrice(linkClass : LinkClass) : Int = {
+    if (!standardPrice.contains(linkClass)) {
+      standardPrice.put(linkClass, Pricing.computeStandardPrice(distance, flightType, linkClass))
+    }
+    standardPrice.get(linkClass)
+  }
   
   
   lazy val schedule : Seq[TimeSlot] = Scheduling.getLinkSchedule(this)
@@ -158,16 +167,16 @@ case class LinkConsideration(link : Link, cost : Double, linkClass : LinkClass, 
     }
 }
 
-sealed abstract class LinkClass(val code : String, val spaceMultiplier : Double, val resourceMultiplier : Double, val priceMultiplier : Double, val level : Int) {
+sealed abstract class LinkClass(val code : String, val spaceMultiplier : Double, val resourceMultiplier : Double, val priceMultiplier : Double, val priceSensitivity : Double, val level : Int) {
   def label : String //level for sorting/comparison purpose
 }
-case object FIRST extends LinkClass("F", spaceMultiplier = 6, resourceMultiplier = 3, priceMultiplier = 9, 3) {
+case object FIRST extends LinkClass("F", spaceMultiplier = 6, resourceMultiplier = 3, priceMultiplier = 9, priceSensitivity = 0.4, level = 3) {
   override def label = "first"
 }
-case object BUSINESS extends LinkClass("J", spaceMultiplier = 2.5, resourceMultiplier = 2, priceMultiplier = 3, 2) {
+case object BUSINESS extends LinkClass("J", spaceMultiplier = 2.5, resourceMultiplier = 2, priceMultiplier = 3, priceSensitivity = 0.7, level = 2) {
   override def label = "business"
 }
-case object ECONOMY extends LinkClass("Y", spaceMultiplier = 1, resourceMultiplier = 1, priceMultiplier = 1, 1) {
+case object ECONOMY extends LinkClass("Y", spaceMultiplier = 1, resourceMultiplier = 1, priceMultiplier = 1, priceSensitivity = 1.0, level =1) {
   override def label = "economy"
 }
 object LinkClass {

--- a/airline-data/src/test/scala/com/patson/PassengerSimulationSpec.scala
+++ b/airline-data/src/test/scala/com/patson/PassengerSimulationSpec.scala
@@ -755,8 +755,8 @@ class PassengerSimulationSpec(_system: ActorSystem) extends TestKit(_system) wit
           }
         }
       }
-      assert(totalAcceptedRoutes / totalRoutes.toDouble > 0.4)
-      assert(totalAcceptedRoutes / totalRoutes.toDouble < 0.6)
+      assert(totalAcceptedRoutes / totalRoutes.toDouble > 0.5)
+      assert(totalAcceptedRoutes / totalRoutes.toDouble < 0.7)
     }
     
     "accept almost no link at 1.5 suggested price with 0 quality and no loyalty".in { 

--- a/airline-data/src/test/scala/com/patson/model/FlightPreferenceSpec.scala
+++ b/airline-data/src/test/scala/com/patson/model/FlightPreferenceSpec.scala
@@ -643,10 +643,10 @@ class FlightPreferenceSpec(_system: ActorSystem) extends TestKit(_system) with I
       println(ratios)
       assert(ratios(ECONOMY) > ratios(BUSINESS))
       assert(ratios(BUSINESS) > ratios(FIRST))
-      assert(ratios(FIRST) > 2)
-      assert(ratios(FIRST) < 2.5)
-      assert(ratios(ECONOMY) > 2.5)
-      assert(ratios(ECONOMY) < 3.5)
+      assert(ratios(FIRST) > 2.5)
+      assert(ratios(FIRST) < 3.5)
+      assert(ratios(ECONOMY) > 3)
+      assert(ratios(ECONOMY) < 4)
 
     }
   }


### PR DESCRIPTION
- Easier to attract business and first class passengers as their quality expectation is lowered
- Passengers are slightly less willing to downgrade (for example from business to economy class)
- Passengers are less willing to switch airlines for transits
- High flight frequency (> 14 per week) will be more attractive to passenger with preference "Swift"
- Business and First class passengers are less sensitive to price changes
- Code optimization to avoid some redundant calculations
- Business and First class passenger favors direct flights more