### PR TITLE
Airplane renewal changes

### DIFF
--- a/airline-data/db_scripts/add_airplane_purchase_cycle.sql
+++ b/airline-data/db_scripts/add_airplane_purchase_cycle.sql
@@ -1,0 +1,4 @@
+ALTER TABLE `airline`.`airplane`
+ADD COLUMN `purchased_cycle` INT(11) NULL DEFAULT NULL AFTER `constructed_cycle`;
+
+UPDATE `airline`.`airplane` SET purchased_cycle = constructed_cycle

--- a/airline-data/src/main/scala/com/patson/AirplaneSimulation.scala
+++ b/airline-data/src/main/scala/com/patson/AirplaneSimulation.scala
@@ -4,7 +4,9 @@ import scala.collection.mutable.ListBuffer
 import com.patson.data._
 import com.patson.model._
 import com.patson.model.airplane._
+
 import scala.collection.mutable.Map
+import scala.util.Random
 
 
 object AirplaneSimulation {
@@ -36,7 +38,7 @@ object AirplaneSimulation {
     println("Finished updating all airplanes")
     
     println("Start renewing airplanes")
-    updatingAirplanes = renewAirplanes(updatingAirplanes)
+    updatingAirplanes = renewAirplanes(updatingAirplanes, cycle)
     println("Finished renewing airplanes")
     
     println("Start retiring airplanes")
@@ -46,12 +48,13 @@ object AirplaneSimulation {
     
     updatingAirplanes.toList
   }
-  
+
+  val SECOND_HAND_MAX_AIRPLANE_COUNT = 50 //only 50 max at a time
   def secondHandAirplaneSimulate(cycle : Int) = {
     var secondHandAirplanes = AirplaneSource.loadAirplanesCriteria(List(("is_sold", true)))
     secondHandAirplanes = secondHandAirplanes.map(airplane => airplane.copy(dealerRatio = airplane.dealerRatio - DEALER_RATIO_DROP_RATE))
     
-    val updatingAirplanes = ListBuffer[Airplane]()
+    var updatingAirplanes = ListBuffer[Airplane]()
     val removingAirplanes = ListBuffer[Airplane]()
     secondHandAirplanes.foreach { airplane =>
       if (airplane.dealerRatio >= DEALER_RATIO_LOWER_THERSHOLD) {
@@ -60,6 +63,14 @@ object AirplaneSimulation {
         removingAirplanes.append(airplane)
       }
     }
+    if (updatingAirplanes.length > SECOND_HAND_MAX_AIRPLANE_COUNT) {
+      val removalCount = updatingAirplanes.length - SECOND_HAND_MAX_AIRPLANE_COUNT
+      updatingAirplanes = Random.shuffle(updatingAirplanes) //randomly drop some airplanes
+      removingAirplanes.appendAll(updatingAirplanes.take(removalCount))
+      updatingAirplanes = updatingAirplanes.drop(removalCount)
+    }
+
+
     AirplaneSource.updateAirplanesDetails(updatingAirplanes.toList)
     removingAirplanes.foreach { airplane =>
       AirplaneSource.deleteAirplanesByCriteria(List(("id", airplane.id), ("is_sold", true))) //need to be careful here, make sure it is still in 2nd hand market
@@ -71,17 +82,20 @@ object AirplaneSimulation {
   val DEALER_RATIO_LOWER_THERSHOLD = Computation.SELL_RATE //at this ratio, the dealer would just scrap the airplane
   
   
-  def renewAirplanes(airplanes : List[Airplane]) : List[Airplane] = {
+  def renewAirplanes(airplanes : List[Airplane], currentCycle : Int) : List[Airplane] = {
     val renewalThresholdsByAirline : scala.collection.immutable.Map[Int, Int] = AirlineSource.loadAirplaneRenewals()
     val costsByAirline : Map[Int, (Long, Long, Long, Long)] = Map[Int, (Long, Long, Long, Long)]()
     val airlinesByid = AirlineSource.loadAllAirlines(false).map(airline => (airline.id, airline)).toMap
     val renewedAirplanes : ListBuffer[Airplane] = ListBuffer[Airplane]() 
     val secondHandAirplanes  = ListBuffer[Airplane]()
-    
-    val updatingAirplanes = airplanes.map { airplane => 
+
+
+    val updatingAirplanes = airplanes.map { airplane =>
       renewalThresholdsByAirline.get(airplane.owner.id) match {
         case Some(threshold) =>
-          if (airplane.condition < threshold ) {
+
+          if (airplane.condition < threshold
+            && airplane.purchasedCycle <= currentCycle - airplane.model.constructionTime) { //only renew airplane if it has been purchased longer than the construction time required
              val airlineId = airplane.owner.id 
              val (existingCost, existingBuyPlane, existingSellPlane, existingCapitalLost) : (Long, Long, Long, Long) = costsByAirline.getOrElse(airlineId, (0, 0, 0, 0))
              val sellValue = Computation.calculateAirplaneSellValue(airplane)
@@ -97,7 +111,7 @@ object AirplaneSimulation {
                if (airplane.condition >= Airplane.BAD_CONDITION) { //create a clone as the sold airplane
                  secondHandAirplanes.append(airplane.copy(isSold = true, dealerRatio = Airplane.DEFAULT_DEALER_RATIO, id = 0))
                }
-               val renewedAirplane = airplane.copy(constructedCycle = MainSimulation.currentWeek, condition = Airplane.MAX_CONDITION, value = airplane.model.price)
+               val renewedAirplane = airplane.copy(constructedCycle = currentCycle, purchasedCycle = currentCycle, condition = Airplane.MAX_CONDITION, value = airplane.model.price)
                renewedAirplanes.append(renewedAirplane)
                renewedAirplane
              } else { //not enough fund

--- a/airline-data/src/main/scala/com/patson/data/Meta.scala
+++ b/airline-data/src/main/scala/com/patson/data/Meta.scala
@@ -528,6 +528,7 @@ object Meta {
       "model INTEGER, " +
       "owner INTEGER, " +
       "constructed_cycle INTEGER, " +
+      "purchased_cycle INTEGER, " +
       "airplane_condition DECIMAL(7,4), " +
       "depreciation_rate INTEGER, " +
       "value INTEGER," +

--- a/airline-data/src/main/scala/com/patson/init/AirlineGenerator.scala
+++ b/airline-data/src/main/scala/com/patson/init/AirlineGenerator.scala
@@ -127,7 +127,7 @@ object AirlineGenerator extends App {
               
               //make airplanes :)
               for (i <- 0 until airplanesRequired) {
-                val newAirplane = Airplane(model = model, owner = airline, constructedCycle = 0 , condition =  Airplane.MAX_CONDITION, depreciationRate = 0, value = model.price)
+                val newAirplane = Airplane(model = model, owner = airline, constructedCycle = 0 , purchasedCycle = 0, condition =  Airplane.MAX_CONDITION, depreciationRate = 0, value = model.price)
                 AirplaneSource.saveAirplanes(List(newAirplane))
                 airplanes += newAirplane
               }

--- a/airline-data/src/main/scala/com/patson/model/airplane/Airplane.scala
+++ b/airline-data/src/main/scala/com/patson/model/airplane/Airplane.scala
@@ -3,7 +3,7 @@ package com.patson.model.airplane
 import com.patson.model.Airline
 import com.patson.model.IdObject
 
-case class Airplane(model : Model, var owner : Airline, constructedCycle : Int, condition : Double, depreciationRate : Int, value : Int, var isSold : Boolean = false, var dealerRatio : Double = Airplane.DEFAULT_DEALER_RATIO, var id : Int = 0) extends IdObject {
+case class Airplane(model : Model, var owner : Airline, constructedCycle : Int, var purchasedCycle : Int, condition : Double, depreciationRate : Int, value : Int, var isSold : Boolean = false, var dealerRatio : Double = Airplane.DEFAULT_DEALER_RATIO, var id : Int = 0) extends IdObject {
   val isReady = (currentCycle : Int) => currentCycle >= constructedCycle && !isSold
   val dealerValue = {
     (value * dealerRatio).toInt
@@ -14,10 +14,11 @@ case class Airplane(model : Model, var owner : Airline, constructedCycle : Int, 
     isSold = true
   }
   
-  def buyFromDealer(airline : Airline) = {
+  def buyFromDealer(airline : Airline, currentCycle : Int) = {
     owner = airline
     dealerRatio = Airplane.DEFAULT_DEALER_RATIO
     isSold = false
+    purchasedCycle = currentCycle
   }
 }
 

--- a/airline-data/src/test/scala/com/patson/AirplaneModelSpec.scala
+++ b/airline-data/src/test/scala/com/patson/AirplaneModelSpec.scala
@@ -49,7 +49,7 @@ class AirplaneModelSpec extends WordSpecLike with Matchers {
     airline.setMaintainenceQuality(Airline.MAX_MAINTENANCE_QUALITY)
     
     val link = Link(fromAirport, toAirport, airline, price = price, distance = distance, LinkClassValues.getInstanceByMap(Map(ECONOMY -> capacity)), rawQuality = fromAirport.expectedQuality(flightType, ECONOMY), duration, frequency, flightType)
-    val airplane = Airplane(airplaneModel, airline, constructedCycle = 0 , Airplane.MAX_CONDITION, depreciationRate = 0, value = airplaneModel.price)
+    val airplane = Airplane(airplaneModel, airline, constructedCycle = 0 , purchasedCycle = 0, Airplane.MAX_CONDITION, depreciationRate = 0, value = airplaneModel.price)
     
     val updatedAirplane = AirplaneSimulation.decayAirplanesByAirline(List((airplane, Some(link))), airline)(0)
     link.setAssignedAirplanes(List(updatedAirplane))

--- a/airline-data/src/test/scala/com/patson/AirplaneSimulationSpec.scala
+++ b/airline-data/src/test/scala/com/patson/AirplaneSimulationSpec.scala
@@ -11,8 +11,8 @@ class AirplaneSimulationSpec extends WordSpecLike with Matchers {
   val airline2 = Airline("test-2")
   airline2.setMaintainenceQuality(70)
    
-  val airplane1 = Airplane(model, airline1, 0, 100, 0, model.price)
-  val airplane2 = Airplane(model, airline2, 0, 100, 0, model.price)
+  val airplane1 = Airplane(model, airline1, 0, 0, 100, 0, model.price)
+  val airplane2 = Airplane(model, airline2, 0, 0, 100, 0, model.price)
   val airport1 = Airport.fromId(1)
   val airport2 = Airport.fromId(2)
   val link1 = Link(airport1, airport2, airline1, LinkClassValues.getInstance(), 0, LinkClassValues.getInstance(), 0, 0, 1, FlightType.SHORT_HAUL_DOMESTIC)

--- a/airline-data/src/test/scala/com/patson/AirportSimulationSpec.scala
+++ b/airline-data/src/test/scala/com/patson/AirportSimulationSpec.scala
@@ -65,8 +65,8 @@ class AirportSimulationSpec extends WordSpecLike with Matchers {
       val smallAirplaneModel = Model.modelByName("Bombardier CS100")
       val largeAirplaneModel = Model.modelByName("Boeing 747-400")
       
-      val smallAirplane = Airplane(smallAirplaneModel, Airline.fromId(1), 0, 100, AirplaneSimulation.computeDepreciationRate(smallAirplaneModel, Airplane.MAX_CONDITION.toDouble / smallAirplaneModel.lifespan), smallAirplaneModel.price)
-      val largeAirplane = Airplane(largeAirplaneModel, Airline.fromId(1), 0, 100, AirplaneSimulation.computeDepreciationRate(largeAirplaneModel, Airplane.MAX_CONDITION.toDouble / largeAirplaneModel.lifespan), largeAirplaneModel.price)
+      val smallAirplane = Airplane(smallAirplaneModel, Airline.fromId(1), 0, purchasedCycle = 0, 100, AirplaneSimulation.computeDepreciationRate(smallAirplaneModel, Airplane.MAX_CONDITION.toDouble / smallAirplaneModel.lifespan), smallAirplaneModel.price)
+      val largeAirplane = Airplane(largeAirplaneModel, Airline.fromId(1), 0, purchasedCycle = 0, 100, AirplaneSimulation.computeDepreciationRate(largeAirplaneModel, Airplane.MAX_CONDITION.toDouble / largeAirplaneModel.lifespan), largeAirplaneModel.price)
       
       val consumptions = ListBuffer[LinkConsumptionDetails]()
       List(smallAirplane, largeAirplane).foreach { airplane =>

--- a/airline-data/src/test/scala/com/patson/LinkSimulationSpec.scala
+++ b/airline-data/src/test/scala/com/patson/LinkSimulationSpec.scala
@@ -36,11 +36,11 @@ class LinkSimulationSpec(_system: ActorSystem) extends TestKit(_system) with Imp
   val mediumModel = Model.modelByName("Boeing 787-8 Dreamliner")
   val largeAirplaneModel = Model.modelByName("Boeing 747-400")
                       
-  val lightAirplane = Airplane(lightModel, testAirline1, 0, 100, AirplaneSimulation.computeDepreciationRate(lightModel, Airplane.MAX_CONDITION.toDouble / lightModel.lifespan), lightModel.price)      
-  val regionalAirplane = Airplane(regionalModel, testAirline1, 0, 100, AirplaneSimulation.computeDepreciationRate(regionalModel, Airplane.MAX_CONDITION.toDouble / regionalModel.lifespan), regionalModel.price)
-  val smallAirplane = Airplane(smallModel, testAirline1, 0, 100, AirplaneSimulation.computeDepreciationRate(smallModel, Airplane.MAX_CONDITION.toDouble / smallModel.lifespan), smallModel.price)
-  val mediumAirplane = Airplane(mediumModel, testAirline1, 0, 100, AirplaneSimulation.computeDepreciationRate(mediumModel, Airplane.MAX_CONDITION.toDouble / mediumModel.lifespan), mediumModel.price)
-  val largeAirplane = Airplane(largeAirplaneModel, testAirline1, 0, 100, AirplaneSimulation.computeDepreciationRate(largeAirplaneModel, Airplane.MAX_CONDITION.toDouble / largeAirplaneModel.lifespan), largeAirplaneModel.price)
+  val lightAirplane = Airplane(lightModel, testAirline1, 0, purchasedCycle = 0, 100, AirplaneSimulation.computeDepreciationRate(lightModel, Airplane.MAX_CONDITION.toDouble / lightModel.lifespan), lightModel.price)
+  val regionalAirplane = Airplane(regionalModel, testAirline1, 0, purchasedCycle = 0, 100, AirplaneSimulation.computeDepreciationRate(regionalModel, Airplane.MAX_CONDITION.toDouble / regionalModel.lifespan), regionalModel.price)
+  val smallAirplane = Airplane(smallModel, testAirline1, 0, purchasedCycle = 0, 100, AirplaneSimulation.computeDepreciationRate(smallModel, Airplane.MAX_CONDITION.toDouble / smallModel.lifespan), smallModel.price)
+  val mediumAirplane = Airplane(mediumModel, testAirline1, 0, purchasedCycle = 0, 100, AirplaneSimulation.computeDepreciationRate(mediumModel, Airplane.MAX_CONDITION.toDouble / mediumModel.lifespan), mediumModel.price)
+  val largeAirplane = Airplane(largeAirplaneModel, testAirline1, 0, purchasedCycle = 0, 100, AirplaneSimulation.computeDepreciationRate(largeAirplaneModel, Airplane.MAX_CONDITION.toDouble / largeAirplaneModel.lifespan), largeAirplaneModel.price)
   
   import Model.Type._
   //LIGHT, REGIONAL, SMALL, MEDIUM, LARGE, JUMBO
@@ -506,7 +506,7 @@ class LinkSimulationSpec(_system: ActorSystem) extends TestKit(_system) with Imp
     link.addSoldSeats(LinkClassValues.getInstanceByMap(Map(ECONOMY -> (capacity * loadFactor).toInt)))
     
     link.setAssignedAirplanes((0 until airplaneCount).foldRight(List[Airplane]()) { 
-      case (_, foldList) => Airplane(airplaneModel, testAirline1, 0, 100, AirplaneSimulation.computeDepreciationRate(airplaneModel, Airplane.MAX_CONDITION.toDouble / airplaneModel.lifespan), airplaneModel.price) :: foldList  
+      case (_, foldList) => Airplane(airplaneModel, testAirline1, 0, purchasedCycle = 0, 100, AirplaneSimulation.computeDepreciationRate(airplaneModel, Airplane.MAX_CONDITION.toDouble / airplaneModel.lifespan), airplaneModel.price) :: foldList
     })
     
     val consumptionResult = LinkSimulation.computeLinkConsumptionDetail(link , 0)

--- a/airline-data/src/test/scala/com/patson/model/FlightPreferenceSpec.scala
+++ b/airline-data/src/test/scala/com/patson/model/FlightPreferenceSpec.scala
@@ -46,9 +46,9 @@ class FlightPreferenceSpec(_system: ActorSystem) extends TestKit(_system) with I
   airline1Link.setQuality(fromAirport.expectedQuality(flightType, FIRST))
   airline2Link.setQuality(fromAirport.expectedQuality(flightType, FIRST))
   val topAirlineLink = Link(fromAirport, toAirport, testAirline2, defaultPrice, distance = distance, defaultCapacity, rawQuality = 100, 600, 1, flightType) 
-  airline2Link.setAssignedAirplanes(List(Airplane(Model.fromId(0), testAirline1, 0, 100, 0, 0)))
-  airline1Link.setAssignedAirplanes(List(Airplane(Model.fromId(0), testAirline2, 0, 100, 0, 0)))
-  topAirlineLink.setAssignedAirplanes(List(Airplane(Model.fromId(0), topAirline, 0, 100, 0, 0)))
+  airline2Link.setAssignedAirplanes(List(Airplane(Model.fromId(0), testAirline1, 0, purchasedCycle = 0, 100, 0, 0)))
+  airline1Link.setAssignedAirplanes(List(Airplane(Model.fromId(0), testAirline2, 0, purchasedCycle = 0, 100, 0, 0)))
+  topAirlineLink.setAssignedAirplanes(List(Airplane(Model.fromId(0), topAirline, 0, purchasedCycle = 0, 100, 0, 0)))
   
   "An AppealPreference".must {
     "generate similar cost if price and distance is the same, and small differece in loyalty".in {
@@ -365,8 +365,8 @@ class FlightPreferenceSpec(_system: ActorSystem) extends TestKit(_system) with I
       airline1Link.setQuality(100)
       val airline2Link = Link(fromAirport, toAirport, adjustedAirline2, defaultPrice, 10000, defaultCapacity, 0, 600, 1, flightType)
       airline2Link.setQuality(100)
-      airline2Link.setAssignedAirplanes(List(Airplane(Model.fromId(0), adjustedAirline1, 0, 100, 0, 0)))
-      airline1Link.setAssignedAirplanes(List(Airplane(Model.fromId(0), adjustedAirline2, 0, 100, 0, 0)))
+      airline2Link.setAssignedAirplanes(List(Airplane(Model.fromId(0), adjustedAirline1, 0, purchasedCycle = 0, 100, 0, 0)))
+      airline1Link.setAssignedAirplanes(List(Airplane(Model.fromId(0), adjustedAirline2, 0, purchasedCycle = 0, 100, 0, 0)))
       
       fromAirport.initLounges(List(Lounge(adjustedAirline1, allianceId = None, fromAirport, level = 3, status = LoungeStatus.ACTIVE, foundedCycle = 0)))
       toAirport.initLounges(List(Lounge(adjustedAirline1, allianceId = None, toAirport, level = 3, status = LoungeStatus.ACTIVE, foundedCycle = 0)))
@@ -394,8 +394,8 @@ class FlightPreferenceSpec(_system: ActorSystem) extends TestKit(_system) with I
       airline1Link.setQuality(100)
       val airline2Link = Link(fromAirport, toAirport, adjustedAirline2, defaultPrice, 10000, defaultCapacity, 0, 600, 1, flightType)
       airline2Link.setQuality(100)
-      airline2Link.setAssignedAirplanes(List(Airplane(Model.fromId(0), adjustedAirline1, 0, 100, 0, 0)))
-      airline1Link.setAssignedAirplanes(List(Airplane(Model.fromId(0), adjustedAirline2, 0, 100, 0, 0)))
+      airline2Link.setAssignedAirplanes(List(Airplane(Model.fromId(0), adjustedAirline1, 0, purchasedCycle = 0, 100, 0, 0)))
+      airline1Link.setAssignedAirplanes(List(Airplane(Model.fromId(0), adjustedAirline2, 0, purchasedCycle = 0, 100, 0, 0)))
       
       fromAirport.initLounges(List(Lounge(adjustedAirline1, allianceId = None, fromAirport, level = 1, status = LoungeStatus.ACTIVE, foundedCycle = 0)))
       toAirport.initLounges(List(Lounge(adjustedAirline1, allianceId = None, toAirport, level = 1, status = LoungeStatus.ACTIVE, foundedCycle = 0)))
@@ -423,8 +423,8 @@ class FlightPreferenceSpec(_system: ActorSystem) extends TestKit(_system) with I
       airline1Link.setQuality(100)
       val airline2Link = Link(fromAirport, toAirport, adjustedAirline2, defaultPrice, 10000, defaultCapacity, 0, 600, 1, flightType)
       airline2Link.setQuality(100)
-      airline2Link.setAssignedAirplanes(List(Airplane(Model.fromId(0), adjustedAirline1, 0, 100, 0, 0)))
-      airline1Link.setAssignedAirplanes(List(Airplane(Model.fromId(0), adjustedAirline2, 0, 100, 0, 0)))
+      airline2Link.setAssignedAirplanes(List(Airplane(Model.fromId(0), adjustedAirline1, 0, purchasedCycle = 0, 100, 0, 0)))
+      airline1Link.setAssignedAirplanes(List(Airplane(Model.fromId(0), adjustedAirline2, 0, purchasedCycle = 0, 100, 0, 0)))
       
       fromAirport.initLounges(List(Lounge(adjustedAirline1, allianceId = None, fromAirport, level = 3, status = LoungeStatus.ACTIVE, foundedCycle = 0)))
       toAirport.initLounges(List(Lounge(adjustedAirline1, allianceId = None, toAirport, level = 3, status = LoungeStatus.ACTIVE, foundedCycle = 0)))
@@ -452,8 +452,8 @@ class FlightPreferenceSpec(_system: ActorSystem) extends TestKit(_system) with I
       airline1Link.setQuality(100)
       val airline2Link = Link(fromAirport, toAirport, adjustedAirline2, defaultPrice, 10000, defaultCapacity, 0, 600, 1, flightType)
       airline2Link.setQuality(100)
-      airline2Link.setAssignedAirplanes(List(Airplane(Model.fromId(0), adjustedAirline1, 0, 100, 0, 0)))
-      airline1Link.setAssignedAirplanes(List(Airplane(Model.fromId(0), adjustedAirline2, 0, 100, 0, 0)))
+      airline2Link.setAssignedAirplanes(List(Airplane(Model.fromId(0), adjustedAirline1, 0, purchasedCycle = 0, 100, 0, 0)))
+      airline1Link.setAssignedAirplanes(List(Airplane(Model.fromId(0), adjustedAirline2, 0, purchasedCycle = 0, 100, 0, 0)))
       
       fromAirport.initLounges(List(Lounge(adjustedAirline1, allianceId = None, fromAirport, level = 2, status = LoungeStatus.ACTIVE, foundedCycle = 0),
                                    Lounge(adjustedAirline2, allianceId = None, fromAirport, level = 1, status = LoungeStatus.ACTIVE, foundedCycle = 0)))
@@ -482,8 +482,8 @@ class FlightPreferenceSpec(_system: ActorSystem) extends TestKit(_system) with I
       airline1Link.setQuality(100)
       val airline2Link = Link(fromAirport, toAirport, adjustedAirline2, defaultPrice, 10000, defaultCapacity, 0, 600, 1, flightType)
       airline2Link.setQuality(100)
-      airline2Link.setAssignedAirplanes(List(Airplane(Model.fromId(0), adjustedAirline1, 0, 100, 0, 0)))
-      airline1Link.setAssignedAirplanes(List(Airplane(Model.fromId(0), adjustedAirline2, 0, 100, 0, 0)))
+      airline2Link.setAssignedAirplanes(List(Airplane(Model.fromId(0), adjustedAirline1, 0, purchasedCycle = 0, 100, 0, 0)))
+      airline1Link.setAssignedAirplanes(List(Airplane(Model.fromId(0), adjustedAirline2, 0, purchasedCycle = 0, 100, 0, 0)))
       
       fromAirport.initLounges(List(Lounge(adjustedAirline1, allianceId = None, fromAirport, level = 3, status = LoungeStatus.ACTIVE, foundedCycle = 0)))
       toAirport.initLounges(List(Lounge(adjustedAirline1, allianceId = None, toAirport, level = 3, status = LoungeStatus.ACTIVE, foundedCycle = 0)))

--- a/airline-web/app/controllers/package.scala
+++ b/airline-web/app/controllers/package.scala
@@ -103,9 +103,11 @@ package object controllers {
       "price" -> JsNumber(airplane.model.price),
       "condition" -> JsNumber(airplane.condition),
       "constructedCycle" -> JsNumber(airplane.constructedCycle),
+      "purchasedCycle" ->  JsNumber(airplane.purchasedCycle),
       "value" -> JsNumber(airplane.value),
       "sellValue" -> JsNumber(Computation.calculateAirplaneSellValue(airplane)),
-      "dealerValue" -> JsNumber(airplane.dealerValue)
+      "dealerValue" -> JsNumber(airplane.dealerValue),
+      "dealerRatio" -> JsNumber(airplane.dealerRatio)
       ))
     }
   }

--- a/airline-web/app/models/StartupProfile.scala
+++ b/airline-web/app/models/StartupProfile.scala
@@ -31,8 +31,8 @@ class RevivalProfile extends StartupProfile(title = "Revival of past glory",
 		  
 		  val model = ModelSource.loadModelsByCriteria(List(("name", "Boeing 737-700C")))(0)
 		  val airplanes = List(
-		      Airplane(model, owner = airline, constructedCycle = cycle, condition = Airplane.MAX_CONDITION / 2, depreciationRate = 0, value = model.price / 2),
-		      Airplane(model, owner = airline, constructedCycle = cycle, condition = Airplane.MAX_CONDITION / 2, depreciationRate = 0, value = model.price / 2))
+		      Airplane(model, owner = airline, constructedCycle = cycle, purchasedCycle = cycle, condition = Airplane.MAX_CONDITION / 2, depreciationRate = 0, value = model.price / 2),
+		      Airplane(model, owner = airline, constructedCycle = cycle, purchasedCycle = cycle, condition = Airplane.MAX_CONDITION / 2, depreciationRate = 0, value = model.price / 2))
 		  AirplaneSource.saveAirplanes(airplanes)
 		  val loan = Loan(airline.id, borrowedAmount = 100000000, interest = 0, remainingAmount = 100000000, creationCycle = 0, loanTerm = 10 * 52)
 		  BankSource.saveLoan(loan)
@@ -58,18 +58,18 @@ class CommuterProfile extends StartupProfile(title = "A humble beginning",
 		  val cessnaModel = ModelSource.loadModelsByCriteria(List(("name", "Cessna 421")))(0)
 		  val erjModel = ModelSource.loadModelsByCriteria(List(("name", "Embraer ERJ140")))(0)
 		  val airplanes = List(
-		      Airplane(cessnaModel, owner = airline, constructedCycle = cycle, condition = Airplane.MAX_CONDITION * 0.8, depreciationRate = 0, value = (cessnaModel.price * 0.8).toInt),
-		      Airplane(cessnaModel, owner = airline, constructedCycle = cycle, condition = Airplane.MAX_CONDITION * 0.8, depreciationRate = 0, value = (cessnaModel.price * 0.8).toInt),
-		      Airplane(cessnaModel, owner = airline, constructedCycle = cycle, condition = Airplane.MAX_CONDITION * 0.8, depreciationRate = 0, value = (cessnaModel.price * 0.8).toInt),
-		      Airplane(cessnaModel, owner = airline, constructedCycle = cycle, condition = Airplane.MAX_CONDITION * 0.8, depreciationRate = 0, value = (cessnaModel.price * 0.8).toInt),
-		      Airplane(cessnaModel, owner = airline, constructedCycle = cycle, condition = Airplane.MAX_CONDITION * 0.8, depreciationRate = 0, value = (cessnaModel.price * 0.8).toInt),
-		      Airplane(cessnaModel, owner = airline, constructedCycle = cycle, condition = Airplane.MAX_CONDITION * 0.8, depreciationRate = 0, value = (cessnaModel.price * 0.8).toInt),
-		      Airplane(cessnaModel, owner = airline, constructedCycle = cycle, condition = Airplane.MAX_CONDITION * 0.8, depreciationRate = 0, value = (cessnaModel.price * 0.8).toInt),
-		      Airplane(cessnaModel, owner = airline, constructedCycle = cycle, condition = Airplane.MAX_CONDITION * 0.8, depreciationRate = 0, value = (cessnaModel.price * 0.8).toInt),
-		      Airplane(erjModel, owner = airline, constructedCycle = cycle, condition = Airplane.MAX_CONDITION * 0.8, depreciationRate = 0, value = (erjModel.price * 0.8).toInt),
-		      Airplane(erjModel, owner = airline, constructedCycle = cycle, condition = Airplane.MAX_CONDITION * 0.8, depreciationRate = 0, value = (erjModel.price * 0.8).toInt),
-		      Airplane(erjModel, owner = airline, constructedCycle = cycle, condition = Airplane.MAX_CONDITION * 0.8, depreciationRate = 0, value = (erjModel.price * 0.8).toInt),
-		      Airplane(erjModel, owner = airline, constructedCycle = cycle, condition = Airplane.MAX_CONDITION * 0.8, depreciationRate = 0, value = (erjModel.price * 0.8).toInt))
+		      Airplane(cessnaModel, owner = airline, constructedCycle = cycle, purchasedCycle = cycle, condition = Airplane.MAX_CONDITION * 0.8, depreciationRate = 0, value = (cessnaModel.price * 0.8).toInt),
+		      Airplane(cessnaModel, owner = airline, constructedCycle = cycle, purchasedCycle = cycle, condition = Airplane.MAX_CONDITION * 0.8, depreciationRate = 0, value = (cessnaModel.price * 0.8).toInt),
+		      Airplane(cessnaModel, owner = airline, constructedCycle = cycle, purchasedCycle = cycle, condition = Airplane.MAX_CONDITION * 0.8, depreciationRate = 0, value = (cessnaModel.price * 0.8).toInt),
+		      Airplane(cessnaModel, owner = airline, constructedCycle = cycle, purchasedCycle = cycle, condition = Airplane.MAX_CONDITION * 0.8, depreciationRate = 0, value = (cessnaModel.price * 0.8).toInt),
+		      Airplane(cessnaModel, owner = airline, constructedCycle = cycle, purchasedCycle = cycle, condition = Airplane.MAX_CONDITION * 0.8, depreciationRate = 0, value = (cessnaModel.price * 0.8).toInt),
+		      Airplane(cessnaModel, owner = airline, constructedCycle = cycle, purchasedCycle = cycle, condition = Airplane.MAX_CONDITION * 0.8, depreciationRate = 0, value = (cessnaModel.price * 0.8).toInt),
+		      Airplane(cessnaModel, owner = airline, constructedCycle = cycle, purchasedCycle = cycle, condition = Airplane.MAX_CONDITION * 0.8, depreciationRate = 0, value = (cessnaModel.price * 0.8).toInt),
+		      Airplane(cessnaModel, owner = airline, constructedCycle = cycle, purchasedCycle = cycle, condition = Airplane.MAX_CONDITION * 0.8, depreciationRate = 0, value = (cessnaModel.price * 0.8).toInt),
+		      Airplane(erjModel, owner = airline, constructedCycle = cycle, purchasedCycle = cycle, condition = Airplane.MAX_CONDITION * 0.8, depreciationRate = 0, value = (erjModel.price * 0.8).toInt),
+		      Airplane(erjModel, owner = airline, constructedCycle = cycle, purchasedCycle = cycle, condition = Airplane.MAX_CONDITION * 0.8, depreciationRate = 0, value = (erjModel.price * 0.8).toInt),
+		      Airplane(erjModel, owner = airline, constructedCycle = cycle, purchasedCycle = cycle, condition = Airplane.MAX_CONDITION * 0.8, depreciationRate = 0, value = (erjModel.price * 0.8).toInt),
+		      Airplane(erjModel, owner = airline, constructedCycle = cycle, purchasedCycle = cycle, condition = Airplane.MAX_CONDITION * 0.8, depreciationRate = 0, value = (erjModel.price * 0.8).toInt))
 		      
 		  AirplaneSource.saveAirplanes(airplanes)
 		  val loan = Loan(airline.id, borrowedAmount = 50000000, interest = 0, remainingAmount = 50000000, creationCycle = 0, loanTerm = 10 * 52)

--- a/airline-web/app/views/index.scala.html
+++ b/airline-web/app/views/index.scala.html
@@ -1167,10 +1167,6 @@
 				    			<div class="value" id="airplaneDetailsSellValue"></div>
 					    	</div>
 					    	<div class="table-row">
-				    			<div class="label"><h5>Replace Cost:</h5></div>
-				    			<div class="value" id="airplaneDetailsReplaceCost"></div>
-					    	</div>
-					    	<div class="table-row">
 				    			<div class="label"><h5>Assigned Route:</h5></div>
 				    			<div class="value" id="airplaneDetailsLink"></div>
 					    	</div>
@@ -1179,7 +1175,7 @@
 				    			<img src='@routes.Assets.versioned("images/icons/prohibition.png")'><span class="warning">Not enough cash to replace this airplane</span>
 					    	</div>
 			   				<div class="button" id ="sellAirplaneButton" onclick="sellAirplane($('#actionAirplaneId').val())">Sell</div>
-			   				<div class="button" id ="replaceAirplaneButton" onclick="replaceAirplane($('#actionAirplaneId').val())">Replace</div>
+<!--			   				<div class="button" id ="replaceAirplaneButton" onclick="replaceAirplane($('#actionAirplaneId').val())">Replace</div>-->
 			    		</div>
 			    	</div>
 			    </div> 

--- a/airline-web/build.sbt
+++ b/airline-web/build.sbt
@@ -11,8 +11,6 @@ libraryDependencies ++= Seq(
   ws,
   guice,
   specs2 % Test,
-//  "com.typesafe.akka" %% "akka-actor" % "2.5.26",
-//  "com.typesafe.akka"          %%  "akka-stream" % "2.5.26",
   "com.typesafe.akka" %% "akka-remote" % "2.5.26",
   "default" %% "airline-data" % "1.1-SNAPSHOT",
   "com.google.api-client" % "google-api-client" % "1.30.4",

--- a/airline-web/conf/routes
+++ b/airline-web/conf/routes
@@ -32,7 +32,7 @@ GET		 /airlines/:airlineId/airplane-models	  controllers.AirplaneApplication.get
 GET		 /airlines/:airlineId/airplanes	  controllers.AirplaneApplication.getAirplanes(airlineId : Int, simpleResult : Boolean ?= false)
 GET		 /airlines/:airlineId/airplanes/:airplaneId		controllers.AirplaneApplication.getAirplane(airlineId : Int, airplaneId : Int)
 DELETE	 /airlines/:airlineId/airplanes/:airplaneId		controllers.AirplaneApplication.sellAirplane(airlineId : Int, airplaneId : Int)
-PUT		 /airlines/:airlineId/airplanes/:airplaneId		controllers.AirplaneApplication.replaceAirplane(airlineId : Int, airplaneId : Int)
+#PUT		 /airlines/:airlineId/airplanes/:airplaneId		controllers.AirplaneApplication.replaceAirplane(airlineId : Int, airplaneId : Int)
 PUT	     /airlines/:airlineId/airplanes	  controllers.AirplaneApplication.addAirplane(airlineId : Int, model: Int, quantity: Int)
 GET		 /airlines/:airlineId/links	  	  controllers.LinkApplication.getLinks(airlineId : Int, getProfit : Boolean ?= false, toAirportId : Int = -1)
 PUT 	 /airlines/:airlineId/links 	  controllers.LinkApplication.addLink(airlineId : Int)

--- a/airline-web/public/javascripts/airplane.js
+++ b/airline-web/public/javascripts/airplane.js
@@ -110,7 +110,17 @@ function updateUsedAirplaneTable(sortProperty, sortOrder) {
 	$.each(loadedUsedAirplanes, function(index, usedAirplane) {
 		var row = $("<div class='table-row'></div>")
 		row.append("<div class='cell'>" + usedAirplane.id + "</div>")
-		row.append("<div class='cell' align='right'>$" + commaSeparateNumber(usedAirplane.dealerValue) + "</div>")
+		var priceColor
+		if (usedAirplane.dealerRatio >= 1.1) { //expensive
+		    priceColor = "#D46A6A"
+		} else if (usedAirplane.dealerRatio <= 0.9) { //cheap
+		    priceColor = "#68A357"
+		}
+		var priceDiv = $("<div class='cell' align='right'>$" + commaSeparateNumber(usedAirplane.dealerValue) + "</div>")
+		if (priceColor) {
+		    priceDiv.css("color", priceColor)
+	    }
+		row.append(priceDiv)
 		row.append("<div class='cell' align='right'>" + usedAirplane.condition.toFixed(2) + "%</div>")
 		if (!usedAirplane.rejection) {
 			row.append("<div class='cell' align='right'><img class='clickable' src='assets/images/icons/airplane-plus.png' title='Purchase this airplane' onclick='buyUsedAirplane(" + usedAirplane.id + ")'></div>")
@@ -201,25 +211,25 @@ function sellAirplane(airplaneId) {
 	});
 }
 
-function replaceAirplane(airplaneId) {
-	var airlineId = activeAirline.id
-	var url = "airlines/" + airlineId + "/airplanes/" + airplaneId 
-	$.ajax({
-		type: 'PUT',
-		data: JSON.stringify({}),
-		url: url,
-	    contentType: 'application/json; charset=utf-8',
-	    dataType: 'json',
-	    success: function(response) {
-	    	refreshPanels(airlineId)
-	    	showAirplaneCanvas()
-	    },
-        error: function(jqXHR, textStatus, errorThrown) {
-	            console.log(JSON.stringify(jqXHR));
-	            console.log("AJAX error: " + textStatus + ' : ' + errorThrown);
-	    }
-	});
-}
+//function replaceAirplane(airplaneId) {
+//	var airlineId = activeAirline.id
+//	var url = "airlines/" + airlineId + "/airplanes/" + airplaneId
+//	$.ajax({
+//		type: 'PUT',
+//		data: JSON.stringify({}),
+//		url: url,
+//	    contentType: 'application/json; charset=utf-8',
+//	    dataType: 'json',
+//	    success: function(response) {
+//	    	refreshPanels(airlineId)
+//	    	showAirplaneCanvas()
+//	    },
+//        error: function(jqXHR, textStatus, errorThrown) {
+//	            console.log(JSON.stringify(jqXHR));
+//	            console.log("AJAX error: " + textStatus + ' : ' + errorThrown);
+//	    }
+//	});
+//}
 
 function buyUsedAirplane(airplaneId) {
 	var airlineId = activeAirline.id
@@ -448,8 +458,6 @@ function loadOwnedAirplaneDetails(airplaneId, selectedItem) {
     			$("#airplaneDetailsDeliveryRow").show()
     		}
 	    	$("#airplaneDetailsSellValue").text("$" + commaSeparateNumber(airplane.sellValue))
-	    	var replaceCost = airplane.price - airplane.sellValue
-	    	$("#airplaneDetailsReplaceCost").text("$" + commaSeparateNumber(replaceCost))
 	    	$("#airplaneDetailsLink").empty()
 	    	if (airplane.link) {
 	    		$("#airplaneDetailsLink").append("<a href='javascript:void(0)' onclick='showWorldMap(); selectLinkFromMap(" + airplane.link.id + ", true)'>" + airplane.link.fromAirportName + "(" + airplane.link.fromAirportCity + ") => " + airplane.link.toAirportName + "(" + airplane.link.toAirportCity + ")</a>" )
@@ -464,17 +472,7 @@ function loadOwnedAirplaneDetails(airplaneId, selectedItem) {
 	    	}
 	    	
 	    	$('#ownedAirplaneDetail .rejection').hide()
-	    	if (age >= 0) {
-	    		if (activeAirline.balance >= replaceCost) { 
-	    			$("#replaceAirplaneButton").show()
-	    		} else {
-	    			$("#replaceAirplaneButton").hide()
-	    			$('#ownedAirplaneDetail .rejection').show()
-	    		}
-	    	} else {
-	    		$("#replaceAirplaneButton").hide()
-	    	}
-	    	
+
 	    	$("#airplaneCanvas #ownedAirplaneDetail").fadeIn(200)
 	    	
 	    },


### PR DESCRIPTION
1. Remove "replace" function
2. Reduce the pool of used airplane. If over 50 airplanes, then randomly delete some of the used airplanes
3. Auto renewal check for "purchase cycle" / add purchase cycle to DB
4. Color code airplane. for those -90%, code it green, for those + 110% code it red (use help bubble to explain color)