### PR TITLE
Pax simulation, more tolerant for lower class switch

### DIFF
--- a/airline-data/src/main/scala/com/patson/model/FlightPreference.scala
+++ b/airline-data/src/main/scala/com/patson/model/FlightPreference.scala
@@ -166,7 +166,8 @@ case class AppealPreference(homeAirport : Airport, preferredLinkClass : LinkClas
     
     var perceivedPrice = link.price(linkClass);
     if (linkClass.level != preferredLinkClass.level) {
-      perceivedPrice = (perceivedPrice / linkClass.priceMultiplier * preferredLinkClass.priceMultiplier * 2.5).toInt //have to normalize the price to match the preferred link class, * 2.5 for unwillingness to downgrade
+      val classDiffMultiplier: Double = 1 + (preferredLinkClass.level - linkClass.level) * 0.7
+      perceivedPrice = (perceivedPrice / linkClass.priceMultiplier * preferredLinkClass.priceMultiplier * classDiffMultiplier).toInt //have to normalize the price to match the preferred link class, * 2.5 for unwillingness to downgrade
     }
 
     val standardPrice = link.standardPrice(preferredLinkClass)

--- a/airline-data/src/main/scala/com/patson/model/Link.scala
+++ b/airline-data/src/main/scala/com/patson/model/Link.scala
@@ -77,8 +77,9 @@ case class Link(from : Airport, to : Airport, airline: Airline, price : LinkClas
 
           while (level >= lowestAcceptableLevel) {
             val lowerClass = LinkClass.fromLevel(level)
-            if (availableSeats(lowerClass) > 0) {
-              return Some(lowerClass, availableSeats(lowerClass))
+            val seatsAvailable = availableSeats(lowerClass)
+            if (seatsAvailable > 0) {
+              return Some(lowerClass, seatsAvailable)
             }
             level -= 1
           }


### PR DESCRIPTION
First class/business class should be more tolerant of lower class especially for short hauls

Change:
- More willing to take lower class
- For short haul flights, all classes pax would consider econ seats 
