### PR TITLE
Update AirportFeaturePatcher.scala

### DIFF
--- a/airline-data/src/main/scala/com/patson/init/AirportFeaturePatcher.scala
+++ b/airline-data/src/main/scala/com/patson/init/AirportFeaturePatcher.scala
@@ -12,238 +12,238 @@ object AirportFeaturePatcher extends App {
 
   lazy val featureList = Map(
     INTERNATIONAL_HUB -> Map[String, Int](
-      "JFK" -> 80,
-      "LHR" -> 80,
-      "HKG" -> 70,
-      "SIN" -> 70,
-      "NRT" -> 65,
-      "CDG" -> 60,
+      "JFK" -> 80, //New York
+      "LHR" -> 80, //London Heathrow
+      "HKG" -> 70, //Hong Kong
+      "SIN" -> 70, //Singaport
+      "NRT" -> 65, //Tokyo Narita
+      "CDG" -> 60, //Paris Charles de Gaulle
       "GVA" -> 58, //Geneva
-      "PVG" -> 40,
-      "PEK" -> 20,
-      "SYD" -> 50,
-      "AUH" -> 50,
-      "EZE" -> 20,
-      "MXP" -> 30,
-      "GRU" -> 20,
-      "FRA" -> 40,
-      "YYZ" -> 30,
-      "LAX" -> 40,
-      "MAD" -> 20,
-      "AMS" -> 20,
-      "KUL" -> 20,
-      "FCO" -> 30,
-      "ICN" -> 30,
-      "JNB" -> 20,
-      "SFO" -> 40,
-      "ZRH" -> 40,
-      "IAD" -> 20,
-      "MIA" -> 20,
-      "YVR" -> 20,
-      "BKK" -> 20,
-      "BOS" -> 20,
-      "CGK" -> 20,
-      "TPE" -> 30,
-      "KIX" -> 20,
-      "ARN" -> 20,
-      "MEX" -> 18,
-      "BRU" -> 18,
-      "DOH" -> 15,
-      "WAW" -> 15,
-      "LUX" -> 11,
-      "BOM" -> 10
+      "SYD" -> 50, //Sydney
+      "AUH" -> 50, //Abu Dhabi
+      "PVG" -> 40, //Shanghai
+      "SFO" -> 40, //San Francisco
+      "ZRH" -> 40, //Zurich
+      "FRA" -> 40, //Frankfurt
+      "LAX" -> 40, //Los Angeles
+      "TPE" -> 30, //Taipei
+      "MXP" -> 30, //Milan
+      "YYZ" -> 30, //Toronto
+      "FCO" -> 30, //Rome
+      "ICN" -> 30, //Seoul Incheon
+      "PEK" -> 20, //Beijing
+      "EZE" -> 20, //Buenos Aires
+      "MAD" -> 20, //Madrid
+      "AMS" -> 20, //Amsterdam
+      "KUL" -> 20, //Kuala Lumpur
+      "JNB" -> 20, //Johannesburg
+      "GRU" -> 20, //Sao Paulo
+      "IAD" -> 20, //Washington Dulles
+      "MIA" -> 20, //Miami
+      "YVR" -> 20, //Vancouver
+      "BKK" -> 20, //Bangkok
+      "BOS" -> 20, //Boston
+      "CGK" -> 20, //Jakarta (Indonesia)
+      "KIX" -> 20, //Osaka
+      "ARN" -> 20, //Stockholm
+      "MEX" -> 18, //Mexico City
+      "BRU" -> 18, //Brussels
+      "DOH" -> 15, //Doha
+      "WAW" -> 15, //Warsaw
+      "LUX" -> 11, //Luxembourg
+      "BOM" -> 10 //Mumbai
     ),
     VACATION_HUB -> Map[String, Int](
-      "HNL" -> 80, //honolulu
-      "BKK" -> 70, //bangkok
-      "CDG" -> 65, //paris
+      "HNL" -> 80, //Honolulu
+      "BKK" -> 70, //Bangkok
+      "CDG" -> 65, //Paris
       "MCO" -> 58, //Orlando
       "MLE" -> 55, //Maldives
       "JTR" -> 46, //Santorini
       "PEK" -> 44, //Beijing
       "DPS" -> 43, //Bali
       "NAN" -> 41, //Fiji
-      "VCE" -> 40, //venice
+      "VCE" -> 40, //Venice
       "ATH" -> 40, //Athens
       "DXB" -> 39, //Dubai
       "MLA" -> 39, //Malta
       "PRG" -> 38, //Prague
       "LPA" -> 38, //Gran Canaria
+      "FCO" -> 38, //Rome
       "IST" -> 35, //Istanbul
-      "DMK" -> 35, //Bangkok other airport
+      "DMK" -> 35, //Bangkok Don Mueang
       "TFS" -> 34, //Tenerife
       "PPT" -> 34, //Pape'ete
       "HER" -> 33, //Crete
-      "CNS" -> 33, //Cairns Australia
-      "PUJ" -> 33, //Punta cana
+      "CNS" -> 33, //Cairns (Australia)
+      "PUJ" -> 33, //Punta Cana (Dominican Republic)
       "OKA" -> 32, //Okinawa
       "CUN" -> 32, //Cancun
       "ORY" -> 32, //Paris Orly
-      "GUM" -> 31, //Guam
-      "FCO" -> 38, //Rome
       "JED" -> 32, //Jeddah/Mecca
-      "KIX" -> 30,
+      "GUM" -> 31, //Guam
+      "KIX" -> 30, //Osaka
       "LAS" -> 30, //Vegas
-      "MIA" -> 30,
-      "NRT" -> 28, //Tokyo
-      "HND" -> 28, //Tokyo
-      "VIE" -> 28, //vienna
+      "MIA" -> 30, //Miami
+      "SIN" -> 29, //Singapore
+      "HKG" -> 28, //Hong Kong
+      "NRT" -> 28, //Tokyo Narita
+      "HND" -> 28, //Tokyo Haneda
+      "VIE" -> 28, //Vienna
       "BCN" -> 28, //Barcelona
       "HAV" -> 27, //Havana
-      "MRS" -> 27,
-      "MXP" -> 27,
+      "MRS" -> 27, //Marseille
+      "MXP" -> 27, //Milan
       "SJD" -> 26, //Los Cabos
-      "GIG" -> 26, //Rio
+      "GIG" -> 26, //Rio de Janeiro
       "KOA" -> 25, //Kailua Hawaii
-      "NAS" -> 25, //Bahamas (nassau)
+      "NAS" -> 25, //Bahamas (Nassau)
       "DBV" -> 25, //Dubrovnik (Croatia)
       "KEF" -> 24, //Reykjavik
+      "BUD" -> 24, //Budapest
       "FLL" -> 22, //Fort Lauderdale
+      "NCE" -> 22, //Nice
+      "PSA" -> 22, //Pisa
+      "OSL" -> 22, //Oslo
       "AMS" -> 21, //Amsterdam
-      "TLV" -> 21,
-      "CAI" -> 20,
-      "NCE" -> 22,
-      "LHR" -> 20,
-      "BOM" -> 20,
-      "LAX" -> 20,
-      "YVR" -> 20,
-      "IAD" -> 20, //washington
+      "TLV" -> 21, //Tel Aviv
+      "CPH" -> 21, //Copenhagen
+      "CAI" -> 20, //Cairo
+      "LHR" -> 20, //London Heathrow
+      "BOM" -> 20, //Mumbai
+      "LAX" -> 20, //Los Angeles
+      "YVR" -> 20, //Vancouver
+      "IAD" -> 20, //Washington Dulles
       "SJU" -> 20, //San Juan
       "GRU" -> 20, //Sao Paulo
-      "BNE" -> 20, //brisbane
-      "AKL" -> 20, //auckland
-      "SIN" -> 29, //Singapore
-      "HKG" -> 28, //hong kong
-      "BUD" -> 24, //Budapest
-      "PSA" -> 22,
-      "OSL" -> 22, //Oslo
-      "CPH" -> 21, //Copenhagen
-      "SFO" -> 20,
-      "OOL" -> 20, //Gold Coast Aus
-      "CMB" -> 20, //Colombo, Sri Lanka
+      "BNE" -> 20, //Brisbane
+      "AKL" -> 20, //Auckland
+      "SFO" -> 20, //San Francisco
+      "OOL" -> 20, //Gold Coast (Australia)
+      "CMB" -> 20, //Colombo (Sri Lanka)
       "MRU" -> 20, //Mauritius
-      "KIN" -> 19, //Kingston Jamaica
+      "KIN" -> 19, //Kingston (Jamaica)
       "BWN" -> 19, //Brunei
       "MFM" -> 19, //Macau
       "CTS" -> 19, //Chitose Sapporo
       "HKT" -> 19, //Phuket
       "PMI" -> 19, //Palma De Mallorca
-      "OGG" -> 18, //	Kahului, Hawaii
-      "KUL" -> 19, //	Kuala Lumpur
+      "KUL" -> 19, //Kuala Lumpur
       "LIS" -> 19, //Lisbon
-      "SYX" -> 18, //Sanya China
-      "XIY" -> 18, //Xian china
+      "OGG" -> 18, //Kahului (Hawaii)
+      "SYX" -> 18, //Sanya (China)
+      "XIY" -> 18, //Xian (China)
       "PVG" -> 18, //Shanghai
-      "PER" -> 18, //Perth
-      "FLN" -> 18,
-      "NAP" -> 18,
-      "KRK" -> 18,
+      "PER" -> 18, //Perth (Australia)
+      "FLN" -> 18, //Florianopolis (Brazil)
+      "NAP" -> 18, //Naples
+      "KRK" -> 18, //Krakow
       "VRA" -> 18, //Varadero Cuba
       "HEL" -> 17, //Helsinki
       "LED" -> 17, //St Petersburg
       "CJU" -> 17, //Jeju
-      "HGH" -> 17, //Hangzhou china
+      "HGH" -> 17, //Hangzhou (China)
       "SJO" -> 17, //Costa Rica
-      "LIH" -> 16, //Lihue, Hawaii
+      "LIH" -> 16, //Lihue (Hawaii)
       "CEB" -> 16, //Cebu
-      "ITO" -> 15, //Hilo hawaii
+      "ITO" -> 15, //Hilo (Hawaii)
       "WAW" -> 15, //Warsaw
       "SAW" -> 15, //Istanbul Sabiha Gökçen
-      "KWL" -> 15, //Guilin China
-      "DRW" -> 14, //Darwin Australia
-      "STX" -> 14, //US Virgin Island
-      "MBJ" -> 13, //Montego bay Jamaica
-      "LXA" -> 12, //Lhasa China
+      "KWL" -> 15, //Guilin (China)
+      "DRW" -> 14, //Darwin (Australia)
+      "STX" -> 14, //Christiansted (US Virgin Islands)
+      "MBJ" -> 13, //Montego Bay (Jamaica)
+      "LXA" -> 12, //Lhasa (Tibet/China)
       "MYR" -> 12, //Myrtle Beach
-      "KBV" -> 12, //Krab Thailand
+      "KBV" -> 12, //Krabi (Thailand)
       "AUA" -> 11, //Aruba
       "BGI" -> 11, //Barbados
       "IBZ" -> 11, //Ibiza
-      "TAO" -> 10, //Qingdao China
+      "TAO" -> 10, //Qingdao (China)
       "NOU" -> 10, //Nouméa
-      "YZF" -> 10, //Yellowknife
+      "YZF" -> 10, //Yellowknife (Canada)
       "CUR" -> 10 //Curacao
     ),
     FINANCIAL_HUB -> Map[String, Int](
-      "LHR" -> 80,
-      "JFK" -> 80,
-      "HND" -> 75,
-      "HKG" -> 70,
-      "SIN" -> 70,
-      "ICN" -> 50,
-      "PVG" -> 50,
-      "DXB" -> 44,
-      "ZRH" -> 40,
-      "BOS" -> 39,
-      "SFO" -> 38,
-      "DFW" -> 37,
-      "ORD" -> 35,
-      "DEN" -> 34,
-      "EWR" -> 33,
+      "LHR" -> 80, //London Heathrow
+      "JFK" -> 80, //New York
+      "HND" -> 75, //Tokyo Haneda
+      "HKG" -> 70, //Hong Kong
+      "SIN" -> 70, //Singapore
+      "FRA" -> 54, //Frankfurt
+      "ICN" -> 50, //Seoul Incheon
+      "PVG" -> 50, //Shanghai
+      "DXB" -> 44, //Dubai
+      "ZRH" -> 40, //Zurich
+      "BOS" -> 39, //Boston
+      "SFO" -> 38, //San Francisco
+      "CDG" -> 38, //Paris Charles de Gaulle
+      "DFW" -> 37, //Dallas Fort-Worth
+      "ORD" -> 35, //Chicago O'Hare
+      "DEN" -> 34, //Denver
+      "EWR" -> 33, //Newark
       "SHA" -> 33, //Shanghai Hongqiao
       "LGW" -> 32, //London Gatwick
       "CAN" -> 32, //Guangzhou
       "SZX" -> 31, //Shenzhen
       "IST" -> 30, //Istanbul
-      "MEX" -> 30,
-      "ITM" -> 28,
-      "CLT" -> 28,
-      "ATL" -> 27,
+      "MEX" -> 30, //Mexico City
+      "ITM" -> 28, //Osaka Itami
+      "CLT" -> 28, //Charlotte
+      "ATL" -> 27, //Atlanta
       "ORY" -> 25, //Paris Orly
       "GMP" -> 24, //Seoul Gimpo
-      "TSN" -> 23, //Tianjin
+      "TSN" -> 23, //Tianjin (China)
+      "MUC" -> 23, //Munich
+      "SEA" -> 22, //Seattle
       "BHX" -> 22, //Birmingham
       "DEL" -> 22, //New Delhi
-      "PHX" -> 22,
-      "IAH" -> 21,
-      "YYZ" -> 20,
-      "MSP" -> 19,
-      "LGA" -> 19,
-      "DUS" -> 18,
-      "CGN" -> 18,
-      "OTP" -> 18,
-      "PHL" -> 17,
-      "MUC" -> 23,
-      "SEA" -> 22,
-      "CPT" -> 19,
+      "PHX" -> 22, //Phoenix
+      "PUS" -> 22, //Busan
+      "MEL" -> 22, //Melbourne
+      "KHH" -> 22, //Kaohsiung (Taiwan
+      "IAH" -> 21, //Houston
+      "YYZ" -> 20, //Toronto
+      "FUK" -> 20, //Fukuoka (Japan)
+      "MSP" -> 19, //Minneapolis
+      "LGA" -> 19, //New York La Guardia
+      "CPT" -> 19, //Cape Town
+      "DMK" -> 19, //Bangkok Don Mueang
+      "CPH" -> 19, //Copenhagen
+      "DCA" -> 19, //Washington Ronald Reagan
+      "SVO" -> 19, //Moscow Sheremetyevo
+      "DME" -> 19, //Moscow Domodedovo
+      "NGO" -> 18, //Nagoya (Japan)
+      "MAN" -> 18, //Manchester
+      "HAM" -> 18, //Hamburg
       "BWI" -> 18, //Baltimore
+      "DUS" -> 18, //Dusseldorf
+      "CGN" -> 18, //Cologne
+      "OTP" -> 18, //Bucharest
+      "BSB" -> 18, //Brazilia
+      "YUL" -> 18, //Montreal
+      "PHL" -> 17, //Philadelphia
       "JED" -> 17, //Jeddah/Mecca
       "MAA" -> 17, //Chennai
-      "FUK" -> 20,
-      "PUS" -> 22, //Busan
-      "FLL" -> 15,
-      "BSB" -> 18, //Brazilia
-      "CDG" -> 38, //paris
-      "FRA" -> 54,
-      "DMK" -> 19, //Bangkok other airport
-      "CPH" -> 19, //Copenhagen
-      "NGO" -> 18,
-      "MAN" -> 18,
-      "HAM" -> 18,
-      "CKG" -> 17, //Chongqing
-      "BER" -> 16,
-      "BOG" -> 15, //Bogota alpha-
-      "YUL" -> 18, //Montreal
-      "RUH" -> 15,
+      "CKG" -> 17, //Chongqing (China)
+      "ARN" -> 17, //Stockholm
+      "BER" -> 16, //Berline
+      "SCL" -> 16, //Santiago (Chile)
+      "FLL" -> 15, //Fort Lauderdale
+      "BOG" -> 15, //Bogota
+      "RUH" -> 15, //Riyadh
       "CTU" -> 15, //Chengdu
-      "SCL" -> 16, //Santiago alpha-
-      "DCA" -> 19,
-      "ARN" -> 17,
-      "SVO" -> 19, //Moscow
-      "DME" -> 19, //Moscow
       "WUH" -> 14, //Wuhan
       "NKG" -> 14, //Nanjing
-      "LIM" -> 12, //Lima
-      "MEL" -> 22, //Melbourne
       "CMN" -> 14, //Casablanca
-      "NBO" -> 11, //Nairobi
       "DUB" -> 13, //Dublin
       "LOS" -> 13, //Lagos
-      "ALG" -> 12, //Algeria
       "MNL" -> 13, //Manila
-      "SGN" -> 11, //Ho Chi Minh City
-      "KHH" -> 22 //Kaohsiung
-    ), //frankfrut
+      "LIM" -> 12, //Lima
+      "ALG" -> 12, //Algeria
+      "NBO" -> 11, //Nairobi
+      "SGN" -> 11 //Ho Chi Minh City
+    ), 
     DOMESTIC_AIRPORT -> Map[String, Int]()
   ) + (GATEWAY_AIRPORT -> getGatewayAirports().map(iata => (iata, 0)).toMap)
 


### PR DESCRIPTION
Hi patson! Changes proposed are all cosmetic at this stage. No new charm cities have been added and no charm values adjusted in this change. I will propose charm additions on next commit if this change is accepted. This is just a code cleanup to make it easy to see which airport/cities have charms and the value of those charms.

Changes made are:
1. Added comments detailing all Airport Names for all Charms so airport location is easily recognizable
2. Fixed capitalization of all Airport Names in comments of Charms 
3. Sorted airport by Charm value from highest to lowest