### PR TITLE
Previous leg replacement issue

### DIFF
--- a/airline-data/src/main/scala/com/patson/model/Link.scala
+++ b/airline-data/src/main/scala/com/patson/model/Link.scala
@@ -136,7 +136,7 @@ case class Link(from : Airport, to : Airport, airline: Airline, price : LinkClas
   }
   
   override def toString() = {
-    s"$id; ${airline.name}; ${from.city}(${from.iata}) => ${to.city}(${to.iata}); distance $distance; freq $frequency; capacity $capacity; price $price"
+    s"Flight $id; ${airline.name}; ${from.city}(${from.iata}) => ${to.city}(${to.iata}); distance $distance; freq $frequency; capacity $capacity; price $price"
   }
 
   lazy val schedule : Seq[TimeSlot] = Scheduling.getLinkSchedule(this)
@@ -235,7 +235,7 @@ case class LinkConsideration(link : Transport, cost : Double, linkClass : LinkCl
     def to : Airport = if (inverted) link.from else link.to
     
     override def toString() : String = {
-      this.getClass.getSimpleName + "(" + from.name + " => " + to.name + " " + linkClass + " (inverted?) " + inverted + ")"
+      s"Consideration (${from.name} =>  ${to.name}  ${linkClass} - $link)"
     }
 }
 

--- a/airline-data/src/main/scala/com/patson/model/Shuttle.scala
+++ b/airline-data/src/main/scala/com/patson/model/Shuttle.scala
@@ -16,6 +16,10 @@ case class Shuttle(from : Airport, to : Airport, airline: Airline, distance : In
   override var minorDelayCount : Int = 0
   override var majorDelayCount : Int = 0
   override var cancellationCount : Int = 0
+
+  override def toString() = {
+    s"Shuttle $id; ${airline.name}; ${from.city}(${from.iata}) => ${to.city}(${to.iata}); distance $distance"
+  }
 }
 
 object Shuttle {

--- a/airline-data/src/main/scala/com/patson/model/airplane/Airplane.scala
+++ b/airline-data/src/main/scala/com/patson/model/airplane/Airplane.scala
@@ -47,7 +47,15 @@ case class Airplane(model : Model, var owner : Airline, constructedCycle : Int, 
   }
 
   lazy val utilizationRate : Double = {
-    (Airplane.MAX_FLIGHT_MINUTES - availableFlightMinutes).toDouble / Airplane.MAX_FLIGHT_MINUTES
+    testUtilizationRate match {
+      case Some(rate) => rate
+      case None => (Airplane.MAX_FLIGHT_MINUTES - availableFlightMinutes).toDouble / Airplane.MAX_FLIGHT_MINUTES
+    }
+  }
+
+  var testUtilizationRate : Option[Double] = None
+  def setTestUtilizationRate(rate : Double): Unit = {
+    testUtilizationRate = Some(rate)
   }
 
 //  lazy val remainingFlightHour = usableFlightHour - linkAssignments.map {

--- a/airline-data/src/test/scala/com/patson/AirplaneModelSpec.scala
+++ b/airline-data/src/test/scala/com/patson/AirplaneModelSpec.scala
@@ -7,7 +7,7 @@ import org.scalatest.{Matchers, WordSpecLike}
  
 class AirplaneModelSpec extends WordSpecLike with Matchers {
   private val GOOD_PROFIT_MARGIN = Map(LIGHT -> 0.25, SMALL -> 0.20, REGIONAL -> 0.15, MEDIUM -> 0.05, LARGE -> 0.0, X_LARGE -> -0.05, JUMBO -> -0.1, SUPERSONIC -> -0.05)
-  private val MAX_PROFIT_MARGIN = Map(LIGHT -> 0.6, SMALL -> 0.55, REGIONAL -> 0.50, MEDIUM -> 0.35, LARGE -> 0.3, X_LARGE -> 0.3, JUMBO -> 0.25, SUPERSONIC -> 0.2)
+  private val MAX_PROFIT_MARGIN = Map(LIGHT -> 0.6, SMALL -> 0.55, REGIONAL -> 0.50, MEDIUM -> 0.35, LARGE -> 0.3, X_LARGE -> 0.3, JUMBO -> 0.25, SUPERSONIC -> 0.3)
   
   "all airplane models".must {
     "Generate good profit at MAX LF at suitable range".in {
@@ -54,8 +54,8 @@ class AirplaneModelSpec extends WordSpecLike with Matchers {
     
     val link = Link(fromAirport, toAirport, airline, price = price, distance = distance, LinkClassValues.getInstanceByMap(Map(ECONOMY -> capacity)), rawQuality = fromAirport.expectedQuality(flightType, ECONOMY), duration, frequency, flightType)
     val airplane = Airplane(airplaneModel, airline, constructedCycle = 0 , purchasedCycle = 0, Airplane.MAX_CONDITION, depreciationRate = 0, value = airplaneModel.price, configuration  = AirplaneConfiguration.default(airline, airplaneModel))
-
-    val updatedAirplane = AirplaneSimulation.decayAirplanesByAirline(Map(airplane -> LinkAssignments(Map(link.id -> LinkAssignment(1, 1)))), airline)(0)
+    airplane.setTestUtilizationRate(1)
+    val updatedAirplane = AirplaneSimulation.decayAirplanesByAirline(Map(airplane -> LinkAssignments(Map())), airline)(0)
     link.setTestingAssignedAirplanes(Map(updatedAirplane -> frequency))
     link.addSoldSeats(LinkClassValues.getInstanceByMap(Map(ECONOMY -> (capacity * loadFactor).toInt)))
     

--- a/airline-data/src/test/scala/com/patson/AirplaneSimulationSpec.scala
+++ b/airline-data/src/test/scala/com/patson/AirplaneSimulationSpec.scala
@@ -7,38 +7,63 @@ import org.scalatest.{Matchers, WordSpecLike}
 class AirplaneSimulationSpec extends WordSpecLike with Matchers {
   private[this] val model = Model.modelByName("Cessna 421")
   val airline1 = Airline("test-1")
-  airline1.setMaintenanceQuality(80)
-  val airline2 = Airline("test-2")
-  airline2.setMaintenanceQuality(70)
+  //airline1.setMaintenanceQuality(80)
+  //val airline2 = Airline("test-2")
+  //airline2.setMaintenanceQuality(70)
    
-  val airplane1 = Airplane(model, airline1, 0, 0, 100, 0, model.price)
-  val airplane2 = Airplane(model, airline2, 0, 0, 100, 0, model.price)
+  val airplane1 = Airplane(model, airline1, 0, 0, 100, 0, model.price, id = 1)
+  val airplane2 = Airplane(model, airline1, 0, 0, 100, 0, model.price, id = 2)
   val airport1 = Airport.fromId(1)
   val airport2 = Airport.fromId(2)
   val link1 = Link(airport1, airport2, airline1, LinkClassValues.getInstance(), 0, LinkClassValues.getInstance(), 0, 0, 1, FlightType.SHORT_HAUL_DOMESTIC)
-  val link2 = Link(airport1, airport2, airline2, LinkClassValues.getInstance(), 0, LinkClassValues.getInstance(), 0, 0, 1, FlightType.SHORT_HAUL_DOMESTIC)  
+  //val link2 = Link(airport1, airport2, airline2, LinkClassValues.getInstance(), 0, LinkClassValues.getInstance(), 0, 0, 1, FlightType.SHORT_HAUL_DOMESTIC)
   
   "decayAirplanesByAirline".must {
-    "decay airplane according to airline maintenance quality".in {
-       val result1 = AirplaneSimulation.decayAirplanesByAirline(Map(airplane1 -> LinkAssignments(Map(link1.id -> LinkAssignment(1, 1)))), airline1)
-       val result2 = AirplaneSimulation.decayAirplanesByAirline(Map(airplane2 -> LinkAssignments(Map(link2.id -> LinkAssignment(1, 1)))), airline2)
-       
-       result1(0).condition.should(be > result2(0).condition)
-    }
+//    "decay airplane according to airline maintenance quality".in {
+//       val result1 = AirplaneSimulation.decayAirplanesByAirline(Map(airplane1 -> LinkAssignments(Map(link1.id -> LinkAssignment(1, 1)))), airline1)
+//       val result2 = AirplaneSimulation.decayAirplanesByAirline(Map(airplane2 -> LinkAssignments(Map(link2.id -> LinkAssignment(1, 1)))), airline2)
+//
+//       result1(0).condition.should(be > result2(0).condition)
+//    }
     "decay slower if no assigned link".in {
-       val result1 = AirplaneSimulation.decayAirplanesByAirline(Map(airplane1 -> LinkAssignments(Map(link1.id -> LinkAssignment(1, 1)))), airline1)
-       val result2 = AirplaneSimulation.decayAirplanesByAirline(Map(airplane1.copy() -> LinkAssignments(Map.empty)), airline2)
-       result1(0).condition.should(be < result2(0).condition)
+      val airplane1 = this.airplane1.copy()
+      val airplane2 = this.airplane2.copy()
+      airplane1.setTestUtilizationRate(1)
+      airplane2.setTestUtilizationRate(0)
+       val result1 = AirplaneSimulation.decayAirplanesByAirline(Map(
+         airplane1 -> LinkAssignments(Map()),
+         airplane2 -> LinkAssignments(Map()),
+       ), airline1)
+
+//       val result2 = AirplaneSimulation.decayAirplanesByAirline(Map(airplane1.copy() -> LinkAssignments(Map.empty)), airline2)
+      result1(0).condition.should(be < result1(1).condition)
+      result1(1).condition.should(be < 100.0) //even w/o assignment it should still decay
+    }
+    "decay slower if flying less frequently".in {
+      val airplane1 = this.airplane1.copy()
+      val airplane2 = this.airplane2.copy()
+      airplane1.setTestUtilizationRate(0.1)
+      airplane2.setTestUtilizationRate(1)
+
+      val result1 = AirplaneSimulation.decayAirplanesByAirline(Map(
+        airplane1 -> LinkAssignments(Map()),
+        airplane2 -> LinkAssignments(Map())
+      ), airline1)
+
+      //       val result2 = AirplaneSimulation.decayAirplanesByAirline(Map(airplane1.copy() -> LinkAssignments(Map.empty)), airline2)
+      result1(0).condition.should(be > result1(1).condition)
     }
     "not decay beyond 0% in lifespan".in {
        val badAirline = Airline("bad-airline")
        badAirline.setMaintenanceQuality(0)
        
        var airplane = airplane1.copy(owner = badAirline)
+       airplane.setTestUtilizationRate(1)
        val link = link1.copy(airline = badAirline)
        
        for (i <- 0 until airplane.model.lifespan) {
-         airplane = AirplaneSimulation.decayAirplanesByAirline(Map(airplane -> LinkAssignments(Map(link.id -> LinkAssignment(1, 1)))), badAirline)(0)
+         airplane = AirplaneSimulation.decayAirplanesByAirline(Map(airplane -> LinkAssignments(Map())), badAirline)(0)
+         airplane.setTestUtilizationRate(1)
        }
        
        airplane.condition.should(be >= 0.0)

--- a/airline-data/src/test/scala/com/patson/AirportSimulationSpec.scala
+++ b/airline-data/src/test/scala/com/patson/AirportSimulationSpec.scala
@@ -422,8 +422,10 @@ class AirportSimulationSpec extends WordSpecLike with Matchers {
         allAirports,
         Map((passengerGroup, airport2, Route(List(goodAirline1Link1), 0)) -> 1000),
         Map(1 -> List(Loyalist(airport1, airline1, airport1.population.toInt - 50))))
-      assert(updatingLoyalists.find(loyalist => loyalist.airport.id == airport1.id && loyalist.airline.id == airline1.id).get.amount >= airport1.population.toInt - 50)
-      assert(updatingLoyalists.find(loyalist => loyalist.airport.id == airport1.id && loyalist.airline.id == airline1.id).get.amount <= airport1.population.toInt)
+      if (updatingLoyalists.find(loyalist => loyalist.airport.id == airport1.id && loyalist.airline.id == airline1.id).isDefined) { //possible that there's no change
+        assert(updatingLoyalists.find(loyalist => loyalist.airport.id == airport1.id && loyalist.airline.id == airline1.id).get.amount >= airport1.population.toInt - 50)
+        assert(updatingLoyalists.find(loyalist => loyalist.airport.id == airport1.id && loyalist.airline.id == airline1.id).get.amount <= airport1.population.toInt)
+      }
     }
 
     "No Gain in loyalists if there's only one airline and it's already at max".in {

--- a/airline-data/src/test/scala/com/patson/PassengerSimulationSpec.scala
+++ b/airline-data/src/test/scala/com/patson/PassengerSimulationSpec.scala
@@ -42,11 +42,31 @@ class PassengerSimulationSpec(_system: ActorSystem) extends TestKit(_system) wit
   allAirportIds ++= toAirports.map { _.id }
   allAirportIds += fromAirport.id
   val LOOP_COUNT = 10000
-  
-  
+
+  def assignLinkConsiderationIds(linkConsiderations : List[LinkConsideration]) = {
+    var id = 1
+    linkConsiderations.foreach { linkConsideration =>
+      if (linkConsideration.link.id == 0) {
+        linkConsideration.link.id = id
+      }
+      id += 1
+    }
+  }
+
+  def assignLinkIds(links : List[Link]) = {
+    var id = 1
+    links.foreach { link =>
+      if (link.id == 0) {
+        link.id = id
+      }
+      id += 1
+    }
+  }
+
+
 //  val airline1Link = Link(fromAirport, toAirport, testAirline1, 100, 10000, 10000, 0, 600, 1)
 //  val airline2Link = Link(fromAirport, toAirport, testAirline2, 100, 10000, 10000, 0, 600, 1)
-  val passengerGroup = PassengerGroup(fromAirport, SimplePreference(homeAirport = fromAirport, priceSensitivity = 1, preferredLinkClass = ECONOMY), PassengerType.BUSINESS) 
+  val passengerGroup = PassengerGroup(fromAirport, SimplePreference(homeAirport = fromAirport, priceSensitivity = 1, preferredLinkClass = ECONOMY), PassengerType.BUSINESS)
   //def findShortestRoute(from : Airport, toAirports : Set[Airport], allVertices: Set[Airport], linksWithCost : List[LinkWithCost], maxHop : Int) : Map[Airport, Route] = {
   "Find shortest route".must {
     "find no route if there's no links".in {
@@ -57,6 +77,8 @@ class PassengerSimulationSpec(_system: ActorSystem) extends TestKit(_system) wit
       val links = toAirports.foldRight(List[LinkConsideration]()) { (airport, foldList) =>
         LinkConsideration(Link(fromAirport, airport, testAirline1, LinkClassValues.getInstance(100), 10000, LinkClassValues.getInstance(10000), 0, 600, 1, SHORT_HAUL_DOMESTIC), 100, ECONOMY, false) :: foldList
       }
+      assignLinkConsiderationIds(links)
+
       val routes = PassengerSimulation.findShortestRoute(passengerGroup, toAirports, allAirportIds, links.asJava, Collections.emptyMap[Int, Int](), 3)
       routes.size.shouldBe(toAirports.size)
       toAirports.foreach { toAirport => routes.isDefinedAt(toAirport).shouldBe(true) }
@@ -65,7 +87,8 @@ class PassengerSimulationSpec(_system: ActorSystem) extends TestKit(_system) wit
       val links = List(LinkConsideration(Link(fromAirport, toAirportsList(0), testAirline1, LinkClassValues.getInstance(100), 10000, LinkClassValues.getInstance(10000), 0, 600, 1, SHORT_HAUL_DOMESTIC), 100, ECONOMY, false),
           LinkConsideration(Link(toAirportsList(0), toAirportsList(1), testAirline1, LinkClassValues.getInstance(100), 10000, LinkClassValues.getInstance(10000), 0, 600, 1, SHORT_HAUL_DOMESTIC), 100, ECONOMY, false),
           LinkConsideration(Link(toAirportsList(1), toAirportsList(2), testAirline1, LinkClassValues.getInstance(100), 10000, LinkClassValues.getInstance(10000), 0, 600, 1, SHORT_HAUL_DOMESTIC), 100, ECONOMY, false))
-      
+      assignLinkConsiderationIds(links)
+
       val routes = PassengerSimulation.findShortestRoute(passengerGroup, toAirports, allAirportIds, links.asJava, Collections.emptyMap[Int, Int](), 3)
       routes.isDefinedAt(toAirportsList(2)).shouldBe(true)
       val route = routes.get(toAirportsList(2)).get
@@ -76,7 +99,8 @@ class PassengerSimulationSpec(_system: ActorSystem) extends TestKit(_system) wit
       val links = List(LinkConsideration(Link(toAirportsList(2), toAirportsList(1), testAirline1, LinkClassValues.getInstance(100), 10000, LinkClassValues.getInstance(10000), 0, 600, 1, SHORT_HAUL_DOMESTIC), 100, ECONOMY, true),
           LinkConsideration(Link(toAirportsList(1), toAirportsList(0), testAirline1, LinkClassValues.getInstance(100), 10000, LinkClassValues.getInstance(10000), 0, 600, 1, SHORT_HAUL_DOMESTIC), 100, ECONOMY, true),
           LinkConsideration(Link(toAirportsList(0), fromAirport, testAirline1, LinkClassValues.getInstance(100), 10000, LinkClassValues.getInstance(10000), 0, 600, 1, SHORT_HAUL_DOMESTIC), 100, ECONOMY, true))
-      
+      assignLinkConsiderationIds(links)
+
       val routes = PassengerSimulation.findShortestRoute(passengerGroup, toAirports, allAirportIds, links.asJava, Collections.emptyMap[Int, Int](), 3)
       routes.isDefinedAt(toAirportsList(2)).shouldBe(true)
       val route = routes.get(toAirportsList(2)).get
@@ -87,7 +111,8 @@ class PassengerSimulationSpec(_system: ActorSystem) extends TestKit(_system) wit
      val links = List(LinkConsideration(Link(fromAirport, toAirportsList(0), testAirline1, LinkClassValues.getInstance(100), 10000, LinkClassValues.getInstance(10000), 0, 600, 1, SHORT_HAUL_DOMESTIC), 100, ECONOMY, false),
           LinkConsideration(Link(toAirportsList(0), toAirportsList(1), testAirline1, LinkClassValues.getInstance(100), 10000, LinkClassValues.getInstance(10000), 0, 600, 1, SHORT_HAUL_DOMESTIC), 100, ECONOMY, false),
           LinkConsideration(Link(toAirportsList(1), toAirportsList(2), testAirline1, LinkClassValues.getInstance(100), 10000, LinkClassValues.getInstance(10000), 0, 600, 1, SHORT_HAUL_DOMESTIC), 100, ECONOMY, false))
-      
+      assignLinkConsiderationIds(links)
+
       val routes = PassengerSimulation.findShortestRoute(passengerGroup, toAirports, allAirportIds, links.asJava, Collections.emptyMap[Int, Int](), 2)
       routes.isDefinedAt(toAirportsList(2)).shouldBe(false)
     }
@@ -96,6 +121,8 @@ class PassengerSimulationSpec(_system: ActorSystem) extends TestKit(_system) wit
           LinkConsideration(Link(toAirportsList(0), toAirportsList(1), testAirline1, LinkClassValues.getInstance(100), distance = 3500, LinkClassValues.getInstance(10000), 0, duration = 200, frequency = 42, SHORT_HAUL_DOMESTIC), 3500, ECONOMY, false),
           LinkConsideration(Link(toAirportsList(1), toAirportsList(2), testAirline1, LinkClassValues.getInstance(100), distance = 3500, LinkClassValues.getInstance(10000), 0, duration = 200, frequency = 42, SHORT_HAUL_DOMESTIC), 3500, ECONOMY, false))
      val allLinks = LinkConsideration(Link(fromAirport, toAirportsList(2), testAirline1, LinkClassValues.getInstance(100), 10000, LinkClassValues.getInstance(10000), 0, duration = 600, frequency = 1, SHORT_HAUL_DOMESTIC), 13000, ECONOMY, false) :: cheapLinks
+      assignLinkConsiderationIds(allLinks)
+
       val routes = PassengerSimulation.findShortestRoute(passengerGroup, toAirports, allAirportIds, allLinks.asJava, Collections.emptyMap[Int, Int](), 3)
       routes.isDefinedAt(toAirportsList(2)).shouldBe(true)
       val route = routes.get(toAirportsList(2)).get
@@ -108,20 +135,21 @@ class PassengerSimulationSpec(_system: ActorSystem) extends TestKit(_system) wit
           LinkConsideration(Link(toAirportsList(1), toAirportsList(2), testAirline1, LinkClassValues.getInstance(100), 10000, LinkClassValues.getInstance(10000), 0, duration = 200, frequency = 1, SHORT_HAUL_DOMESTIC), 400, ECONOMY, false))
      val expensiveLink = LinkConsideration(Link(fromAirport, toAirportsList(2), testAirline1, LinkClassValues.getInstance(100), 10000, LinkClassValues.getInstance(10000), 0, duration = 600, frequency = 1, SHORT_HAUL_DOMESTIC), 1400, ECONOMY, false)
      val allLinks =  expensiveLink :: cheapLinks
+      assignLinkConsiderationIds(allLinks)
       val routes = PassengerSimulation.findShortestRoute(passengerGroup, toAirports, allAirportIds, allLinks.asJava, Collections.emptyMap[Int, Int](), 3)
       routes.isDefinedAt(toAirportsList(2)).shouldBe(true)
       val route = routes.get(toAirportsList(2)).get
       route.links.size.shouldBe(1)
       route.links.equals(expensiveLink)
     }
-    
+
     "use expensive route if cheaper route exceed max hop".in {
      val cheapLinks = List(LinkConsideration(Link(fromAirport, toAirportsList(0), testAirline1, LinkClassValues.getInstance(100), 10000, LinkClassValues.getInstance(10000), 0, 600, 1, SHORT_HAUL_DOMESTIC), 100, ECONOMY, false),
           LinkConsideration(Link(toAirportsList(0), toAirportsList(1), testAirline1, LinkClassValues.getInstance(100), 10000, LinkClassValues.getInstance(10000), 0, 600, 1, SHORT_HAUL_DOMESTIC), 100, ECONOMY, false),
           LinkConsideration(Link(toAirportsList(1), toAirportsList(2), testAirline1, LinkClassValues.getInstance(100), 10000, LinkClassValues.getInstance(10000), 0, 600, 1, SHORT_HAUL_DOMESTIC), 100, ECONOMY, false))
      val expensiveLink = LinkConsideration(Link(fromAirport, toAirportsList(2), testAirline1, LinkClassValues.getInstance(100), 10000, LinkClassValues.getInstance(10000), 0, 600, 1, SHORT_HAUL_DOMESTIC), 301, ECONOMY, false)
      val allLinks = expensiveLink :: cheapLinks
-          
+      assignLinkConsiderationIds(allLinks)
       val routes = PassengerSimulation.findShortestRoute(passengerGroup, toAirports, allAirportIds, allLinks.asJava, Collections.emptyMap[Int, Int](), 2)
       routes.isDefinedAt(toAirportsList(2)).shouldBe(true)
       val route = routes.get(toAirportsList(2)).get
@@ -132,7 +160,7 @@ class PassengerSimulationSpec(_system: ActorSystem) extends TestKit(_system) wit
      val links = List(LinkConsideration(Link(fromAirport, toAirportsList(0), testAirline1, LinkClassValues.getInstance(100), 10000, LinkClassValues.getInstance(10000), 0, 600, 1, SHORT_HAUL_DOMESTIC), 100, ECONOMY, false),
           LinkConsideration(Link(toAirportsList(0), toAirportsList(1), testAirline1, LinkClassValues.getInstance(100), 10000, LinkClassValues.getInstance(10000), 0, 600, 1, SHORT_HAUL_DOMESTIC), 100, ECONOMY, true), //wrong direction
           LinkConsideration(Link(toAirportsList(1), toAirportsList(2), testAirline1, LinkClassValues.getInstance(100), 10000, LinkClassValues.getInstance(10000), 0, 600, 1, SHORT_HAUL_DOMESTIC), 100, ECONOMY, false))
-      
+      assignLinkConsiderationIds(links)
       val routes = PassengerSimulation.findShortestRoute(passengerGroup, toAirports, allAirportIds, links.asJava, Collections.emptyMap[Int, Int](), 3)
       routes.isDefinedAt(toAirportsList(2)).shouldBe(false)
     }
@@ -140,9 +168,9 @@ class PassengerSimulationSpec(_system: ActorSystem) extends TestKit(_system) wit
   "findAllRoutes".must {
     "find routes if there're valid links".in {
       val links = List(Link(fromAirport, toAirportsList(0), testAirline1, LinkClassValues.getInstance(100, 100, 100), 10000, LinkClassValues.getInstance(10000, 10000, 10000), 0, 600, 1, SHORT_HAUL_DOMESTIC),
-                      Link(toAirportsList(0), toAirportsList(1), testAirline1, LinkClassValues.getInstance(100, 100, 100), 10000, LinkClassValues.getInstance(10000, 10000, 10000), 0, 600, 1, SHORT_HAUL_DOMESTIC), 
+                      Link(toAirportsList(0), toAirportsList(1), testAirline1, LinkClassValues.getInstance(100, 100, 100), 10000, LinkClassValues.getInstance(10000, 10000, 10000), 0, 600, 1, SHORT_HAUL_DOMESTIC),
                       Link(toAirportsList(1), toAirportsList(2), testAirline1, LinkClassValues.getInstance(100, 100, 100), 10000, LinkClassValues.getInstance(10000, 10000, 10000), 0, 600, 1, SHORT_HAUL_DOMESTIC))
-      
+      assignLinkIds(links)
       val economyPassengerGroup = PassengerGroup(fromAirport, AppealPreference(fromAirport, ECONOMY, loungeLevelRequired = 0, loyaltyRatio = 1, 0), PassengerType.BUSINESS)
       val businessPassengerGroup = PassengerGroup(fromAirport, AppealPreference(fromAirport, BUSINESS, loungeLevelRequired = 0, loyaltyRatio = 1, 0), PassengerType.BUSINESS)
       val firstPassengerGroup = PassengerGroup(fromAirport, AppealPreference(fromAirport, FIRST, loungeLevelRequired = 0, loyaltyRatio = 1, 0), PassengerType.BUSINESS)
@@ -150,14 +178,14 @@ class PassengerSimulationSpec(_system: ActorSystem) extends TestKit(_system) wit
       val toAirports = Set[Airport]()
       toAirports ++= toAirportsList
       val result : Map[PassengerGroup, Map[Airport, Route]] = PassengerSimulation.findAllRoutes(Map(economyPassengerGroup -> toAirports, businessPassengerGroup -> toAirports, firstPassengerGroup -> toAirports), links, allAirportIds)
-      
+
       result.isDefinedAt(economyPassengerGroup).shouldBe(true)
       toAirports.foreach { toAirport =>
         result(economyPassengerGroup).isDefinedAt(toAirport).shouldBe(true)
-        
+
         //should be the right class
         result(economyPassengerGroup)(toAirport).links.foreach { linkConsideration =>
-          assert(linkConsideration.linkClass == ECONOMY)          
+          assert(linkConsideration.linkClass == ECONOMY)
         }
       }
       result.isDefinedAt(businessPassengerGroup).shouldBe(true)
@@ -165,7 +193,7 @@ class PassengerSimulationSpec(_system: ActorSystem) extends TestKit(_system) wit
         result(businessPassengerGroup).isDefinedAt(toAirport).shouldBe(true)
         //should be the right class
         result(businessPassengerGroup)(toAirport).links.foreach { linkConsideration =>
-          assert(linkConsideration.linkClass == BUSINESS)          
+          assert(linkConsideration.linkClass == BUSINESS)
         }
       }
       result.isDefinedAt(firstPassengerGroup).shouldBe(true)
@@ -173,15 +201,15 @@ class PassengerSimulationSpec(_system: ActorSystem) extends TestKit(_system) wit
         result(firstPassengerGroup).isDefinedAt(toAirport).shouldBe(true)
         //should be the right class
         result(firstPassengerGroup)(toAirport).links.foreach { linkConsideration =>
-          assert(linkConsideration.linkClass == FIRST)          
+          assert(linkConsideration.linkClass == FIRST)
         }
       }
     }
     "find routes if there're valid links (from and to inverse)".in {
       val links = List(Link(toAirportsList(2), toAirportsList(1), testAirline1, LinkClassValues.getInstance(100, 100, 100), 10000, LinkClassValues.getInstance(10000, 10000, 10000), 0, 600, 1, SHORT_HAUL_DOMESTIC),
-                      Link(toAirportsList(1), toAirportsList(0), testAirline1, LinkClassValues.getInstance(100, 100, 100), 10000, LinkClassValues.getInstance(10000, 10000, 10000), 0, 600, 1, SHORT_HAUL_DOMESTIC), 
+                      Link(toAirportsList(1), toAirportsList(0), testAirline1, LinkClassValues.getInstance(100, 100, 100), 10000, LinkClassValues.getInstance(10000, 10000, 10000), 0, 600, 1, SHORT_HAUL_DOMESTIC),
                       Link(toAirportsList(0), fromAirport, testAirline1, LinkClassValues.getInstance(100, 100, 100), 10000, LinkClassValues.getInstance(10000, 10000, 10000), 0, 600, 1, SHORT_HAUL_DOMESTIC))
-      
+      assignLinkIds(links)
       val economyPassengerGroup = PassengerGroup(fromAirport, AppealPreference(fromAirport, ECONOMY, loungeLevelRequired = 0, loyaltyRatio = 1, 0), PassengerType.BUSINESS)
       val businessPassengerGroup = PassengerGroup(fromAirport, AppealPreference(fromAirport, BUSINESS, loungeLevelRequired = 0, loyaltyRatio = 1, 0), PassengerType.BUSINESS)
       val firstPassengerGroup = PassengerGroup(fromAirport, AppealPreference(fromAirport, FIRST, loungeLevelRequired = 0, loyaltyRatio = 1, 0), PassengerType.BUSINESS)
@@ -216,7 +244,7 @@ class PassengerSimulationSpec(_system: ActorSystem) extends TestKit(_system) wit
       val links = List(Link(fromAirport, toAirportsList(0), testAirline1, LinkClassValues.getInstance(100, 100, 100), 10000, LinkClassValues.getInstance(100, 100, 100), 0, 600, 1, SHORT_HAUL_DOMESTIC),
                       Link(toAirportsList(0), toAirportsList(1), testAirline1, LinkClassValues.getInstance(100, 100, 100), 10000, LinkClassValues.getInstance(0, 100, 0), 0, 600, 1, SHORT_HAUL_DOMESTIC), 
                       Link(toAirportsList(1), toAirportsList(2), testAirline1, LinkClassValues.getInstance(100, 100, 100), 10000, LinkClassValues.getInstance(100, 0, 0), 0, 600, 1, SHORT_HAUL_DOMESTIC))
-      
+      assignLinkIds(links)
       val economyPassengerGroup = PassengerGroup(fromAirport, AppealPreference(fromAirport, ECONOMY, loungeLevelRequired = 0, loyaltyRatio = 1, 0), PassengerType.BUSINESS)
       val businessPassengerGroup = PassengerGroup(fromAirport, AppealPreference(fromAirport, BUSINESS, loungeLevelRequired = 0, loyaltyRatio = 1, 0), PassengerType.BUSINESS)
       val firstPassengerGroup = PassengerGroup(fromAirport, AppealPreference(fromAirport, FIRST, loungeLevelRequired = 0, loyaltyRatio = 1, 0), PassengerType.BUSINESS)
@@ -260,7 +288,7 @@ class PassengerSimulationSpec(_system: ActorSystem) extends TestKit(_system) wit
       val links = List(Link(clonedFromAirport, toAirportsList(0), testAirline1, LinkClassValues.getInstance(100, 100, 100), 10000, LinkClassValues.getInstance(10000, 10000, 10000), 0, 600, 1, SHORT_HAUL_DOMESTIC),
                       Link(toAirportsList(0), toAirportsList(1), testAirline1, LinkClassValues.getInstance(100, 100, 100), 10000, LinkClassValues.getInstance(10000, 10000, 10000), 0, 600, 1, SHORT_HAUL_DOMESTIC), 
                       Link(toAirportsList(1), toAirportsList(2), testAirline1, LinkClassValues.getInstance(100, 100, 100), 10000, LinkClassValues.getInstance(10000, 10000, 10000), 0, 600, 1, SHORT_HAUL_DOMESTIC))
-      
+      assignLinkIds(links)
       val economyPassengerGroup = PassengerGroup(clonedFromAirport, AppealPreference(clonedFromAirport, ECONOMY, loungeLevelRequired = 0, loyaltyRatio = 1, 0), PassengerType.BUSINESS)
       
       val toAirports = Set[Airport]()
@@ -286,7 +314,7 @@ class PassengerSimulationSpec(_system: ActorSystem) extends TestKit(_system) wit
       val links = List(Link(airport1, airport2, airline1, LinkClassValues.getInstance(100, 100, 100), 10000, LinkClassValues.getInstance(10000, 10000, 10000), 0, 600, 1, SHORT_HAUL_DOMESTIC),
                       Link(airport2, airport3, airline1, LinkClassValues.getInstance(100, 100, 100), 10000, LinkClassValues.getInstance(10000, 10000, 10000), 0, 600, 1, SHORT_HAUL_DOMESTIC), 
                       Link(airport3, airport4, airline1, LinkClassValues.getInstance(100, 100, 100), 10000, LinkClassValues.getInstance(10000, 10000, 10000), 0, 600, 1, SHORT_HAUL_DOMESTIC))
-      
+      assignLinkIds(links)
       val economyPassengerGroup = PassengerGroup(airport1, AppealPreference(airport1, ECONOMY, loungeLevelRequired = 0, loyaltyRatio = 1, 0), PassengerType.BUSINESS)
       val businessPassengerGroup = PassengerGroup(airport1, AppealPreference(airport1, BUSINESS, loungeLevelRequired = 0, loyaltyRatio = 1, 0), PassengerType.BUSINESS)
       val firstPassengerGroup = PassengerGroup(airport1, AppealPreference(airport1, FIRST, loungeLevelRequired = 0, loyaltyRatio = 1, 0), PassengerType.BUSINESS)
@@ -342,7 +370,7 @@ class PassengerSimulationSpec(_system: ActorSystem) extends TestKit(_system) wit
       val links = List(Link(airport1, airport2, airline1, LinkClassValues.getInstance(100, 100, 100), 10000, LinkClassValues.getInstance(10000, 10000, 10000), 0, 600, 1, SHORT_HAUL_DOMESTIC),
                       Link(airport2, airport3, airline1, LinkClassValues.getInstance(100, 100, 100), 10000, LinkClassValues.getInstance(10000, 10000, 10000), 0, 600, 1, SHORT_HAUL_DOMESTIC), 
                       Link(airport3, airport4, airline1, LinkClassValues.getInstance(100, 100, 100), 10000, LinkClassValues.getInstance(10000, 10000, 10000), 0, 600, 1, SHORT_HAUL_DOMESTIC))
-      
+      assignLinkIds(links)
       val economyPassengerGroup = PassengerGroup(airport1, AppealPreference(airport1, ECONOMY, loungeLevelRequired = 0, loyaltyRatio = 1, 0), PassengerType.BUSINESS)
       
       val toAirports = Set[Airport]()
@@ -391,7 +419,7 @@ class PassengerSimulationSpec(_system: ActorSystem) extends TestKit(_system) wit
                       Link(airport2, airport3, airline1, LinkClassValues.getInstance(100, 100, 100), 10000, LinkClassValues.getInstance(10000, 10000, 10000), 0, 600, 1, SHORT_HAUL_DOMESTIC), 
                       Link(airport3, airport4, airline1, LinkClassValues.getInstance(100, 100, 100), 10000, LinkClassValues.getInstance(10000, 10000, 10000), 0, 600, 1, SHORT_HAUL_DOMESTIC),
                       Link(airport4, airport5, airline1, LinkClassValues.getInstance(100, 100, 100), 10000, LinkClassValues.getInstance(10000, 10000, 10000), 0, 600, 1, SHORT_HAUL_DOMESTIC))
-      
+      assignLinkIds(links)
       val economyPassengerGroup = PassengerGroup(airport1, AppealPreference(airport1, ECONOMY, loungeLevelRequired = 0, loyaltyRatio = 1, 0), PassengerType.BUSINESS)
       
       val toAirports = Set[Airport]()
@@ -440,7 +468,7 @@ class PassengerSimulationSpec(_system: ActorSystem) extends TestKit(_system) wit
                       Link(airport4, airport3, airline1, LinkClassValues.getInstance(100, 100, 100), 10000, LinkClassValues.getInstance(10000, 10000, 10000), 0, 600, 1, SHORT_HAUL_DOMESTIC), 
                       Link(airport3, airport2, airline1, LinkClassValues.getInstance(100, 100, 100), 10000, LinkClassValues.getInstance(10000, 10000, 10000), 0, 600, 1, SHORT_HAUL_DOMESTIC),
                       Link(airport2, airport1, airline1, LinkClassValues.getInstance(100, 100, 100), 10000, LinkClassValues.getInstance(10000, 10000, 10000), 0, 600, 1, SHORT_HAUL_DOMESTIC))
-      
+      assignLinkIds(links)
       val economyPassengerGroup = PassengerGroup(airport1, AppealPreference(airport1, ECONOMY, loungeLevelRequired = 0, loyaltyRatio = 1, 0), PassengerType.BUSINESS)
       
       val toAirports = Set[Airport]()
@@ -490,7 +518,7 @@ class PassengerSimulationSpec(_system: ActorSystem) extends TestKit(_system) wit
       val links = List(Link(airport1, airport2, airline1, price = Pricing.computeStandardPriceForAllClass(2000, SHORT_HAUL_DOMESTIC), 2000, capacity = LinkClassValues.getInstance(10000, 10000, 10000), 0, 600, 1, SHORT_HAUL_DOMESTIC),
                       Link(airport2, airport3, airline1, price = Pricing.computeStandardPriceForAllClass(2000, SHORT_HAUL_DOMESTIC), 2000, capacity = LinkClassValues.getInstance(10000, 0, 0), 0, 600, 1, SHORT_HAUL_DOMESTIC),
                       Link(airport2, airport3, airline2, price = Pricing.computeStandardPriceForAllClass(2000, SHORT_HAUL_DOMESTIC), 2000, capacity = LinkClassValues.getInstance(10000, 10000, 10000), 0, 600, 1, SHORT_HAUL_DOMESTIC))
-                      
+      assignLinkIds(links)
       val economyPassengerGroup = PassengerGroup(airport1, AppealPreference(airport1, ECONOMY, loungeLevelRequired = 0, loyaltyRatio = 1, 0), PassengerType.BUSINESS)              
       val businessPassengerGroup = PassengerGroup(airport1, AppealPreference(airport1, BUSINESS, loungeLevelRequired = 0, loyaltyRatio = 1, 0), PassengerType.BUSINESS)
       val firstPassengerGroup = PassengerGroup(airport1, AppealPreference(airport1, FIRST, loungeLevelRequired = 0, loyaltyRatio = 1, 0), PassengerType.BUSINESS)

--- a/airline-data/src/test/scala/com/patson/ShuttleSimulationSpec.scala
+++ b/airline-data/src/test/scala/com/patson/ShuttleSimulationSpec.scala
@@ -21,14 +21,14 @@ class ShuttleSimulationSpec(_system: ActorSystem) extends TestKit(_system) with 
  
   val testAirline1 = Airline("airline 1", id = 1)
   val testAirline2 = Airline("airline 2", id = 2)
-  val fromAirport = Airport.fromId(1).copy(power = 40000, population = 1) //income 40k . mid income country
+  val fromAirport = Airport.fromId(1).copy(power = 40000, population = 1, name = "F0") //income 40k . mid income country
   val airlineAppeal = AirlineAppeal(0, 100)
   fromAirport.initAirlineAppeals(Map(testAirline1.id -> airlineAppeal, testAirline2.id -> airlineAppeal))
   fromAirport.initLounges(List.empty)
   val toAirportsList = List(
-      Airport("", "", "To Airport", 0, 30, "", "", "", 1, 0, 0, 0, id = 2),
-      Airport("", "", "To Airport", 0, 60, "", "", "", 1, 0, 0, 0, id = 3),
-      Airport("", "", "To Airport", 0, 90, "", "", "", 1, 0, 0, 0, id = 4))
+      Airport("", "", "T0", 0, 30, "", "", "", 1, 0, 0, 0, id = 2),
+      Airport("", "", "T1", 0, 60, "", "", "", 1, 0, 0, 0, id = 3),
+      Airport("", "", "T2", 0, 90, "", "", "", 1, 0, 0, 0, id = 4))
   
   
   toAirportsList.foreach { airport =>
@@ -49,9 +49,9 @@ class ShuttleSimulationSpec(_system: ActorSystem) extends TestKit(_system) with 
   //def findShortestRoute(from : Airport, toAirports : Set[Airport], allVertices: Set[Airport], linksWithCost : List[LinkWithCost], maxHop : Int) : Map[Airport, Route] = {
   "Find shortest route".must {
     "find a route if there's shuttle offered by same airline".in {
-      var links = List(LinkConsideration(Shuttle(fromAirport, toAirportsList(0), testAirline1, 50, LinkClassValues.getInstance(10000)), 100, ECONOMY, false),
-          LinkConsideration(Link(toAirportsList(0), toAirportsList(1), testAirline1, LinkClassValues.getInstance(100), 10000, LinkClassValues.getInstance(10000), 0, 600, 1, SHORT_HAUL_DOMESTIC), 100, ECONOMY, false),
-          LinkConsideration(Link(toAirportsList(1), toAirportsList(2), testAirline1, LinkClassValues.getInstance(100), 10000, LinkClassValues.getInstance(10000), 0, 600, 1, SHORT_HAUL_DOMESTIC), 100, ECONOMY, false))
+      var links = List(LinkConsideration(Shuttle(fromAirport, toAirportsList(0), testAirline1, 50, LinkClassValues.getInstance(10000), id = 1), 100, ECONOMY, false),
+          LinkConsideration(Link(toAirportsList(0), toAirportsList(1), testAirline1, LinkClassValues.getInstance(100), 10000, LinkClassValues.getInstance(10000), 0, 600, 1, SHORT_HAUL_DOMESTIC, id = 2), 100, ECONOMY, false),
+          LinkConsideration(Link(toAirportsList(1), toAirportsList(2), testAirline1, LinkClassValues.getInstance(100), 10000, LinkClassValues.getInstance(10000), 0, 600, 1, SHORT_HAUL_DOMESTIC, id = 3), 100, ECONOMY, false))
       
       var routes = PassengerSimulation.findShortestRoute(passengerGroup, toAirports, allAirportIds, links.asJava, Collections.emptyMap[Int, Int](), 3)
       routes.isDefinedAt(toAirportsList(2)).shouldBe(true)
@@ -60,9 +60,9 @@ class ShuttleSimulationSpec(_system: ActorSystem) extends TestKit(_system) with 
       route.links.equals(links)
 
       links = List(
-        LinkConsideration(Link(fromAirport, toAirportsList(0), testAirline1, LinkClassValues.getInstance(100), 10000, LinkClassValues.getInstance(10000), 0, 600, 1, SHORT_HAUL_DOMESTIC), 100, ECONOMY, false),
-        LinkConsideration(Shuttle(toAirportsList(0), toAirportsList(1), testAirline1, 50, LinkClassValues.getInstance(10000)), 100, ECONOMY, false),
-        LinkConsideration(Link(toAirportsList(1), toAirportsList(2), testAirline1, LinkClassValues.getInstance(100), 10000, LinkClassValues.getInstance(10000), 0, 600, 1, SHORT_HAUL_DOMESTIC), 100, ECONOMY, false))
+        LinkConsideration(Link(fromAirport, toAirportsList(0), testAirline1, LinkClassValues.getInstance(100), 10000, LinkClassValues.getInstance(10000), 0, 600, 1, SHORT_HAUL_DOMESTIC, id = 1), 100, ECONOMY, false),
+        LinkConsideration(Shuttle(toAirportsList(0), toAirportsList(1), testAirline1, 50, LinkClassValues.getInstance(10000), id = 2), 100, ECONOMY, false),
+        LinkConsideration(Link(toAirportsList(1), toAirportsList(2), testAirline1, LinkClassValues.getInstance(100), 10000, LinkClassValues.getInstance(10000), 0, 600, 1, SHORT_HAUL_DOMESTIC, id = 3), 100, ECONOMY, false))
 
       routes = PassengerSimulation.findShortestRoute(passengerGroup, toAirports, allAirportIds, links.asJava, Collections.emptyMap[Int, Int](), 3)
       routes.isDefinedAt(toAirportsList(2)).shouldBe(true)
@@ -71,9 +71,9 @@ class ShuttleSimulationSpec(_system: ActorSystem) extends TestKit(_system) with 
       route.links.equals(links)
 
       links = List(
-        LinkConsideration(Link(fromAirport, toAirportsList(0), testAirline1, LinkClassValues.getInstance(100), 10000, LinkClassValues.getInstance(10000), 0, 600, 1, SHORT_HAUL_DOMESTIC), 100, ECONOMY, false),
-        LinkConsideration(Link(toAirportsList(0), toAirportsList(1), testAirline1, LinkClassValues.getInstance(100), 10000, LinkClassValues.getInstance(10000), 0, 600, 1, SHORT_HAUL_DOMESTIC), 100, ECONOMY, false),
-        LinkConsideration(Shuttle(toAirportsList(1), toAirportsList(2), testAirline1, 50, LinkClassValues.getInstance(10000)), 100, ECONOMY, false))
+        LinkConsideration(Link(fromAirport, toAirportsList(0), testAirline1, LinkClassValues.getInstance(100), 10000, LinkClassValues.getInstance(10000), 0, 600, 1, SHORT_HAUL_DOMESTIC, id = 1), 100, ECONOMY, false),
+        LinkConsideration(Link(toAirportsList(0), toAirportsList(1), testAirline1, LinkClassValues.getInstance(100), 10000, LinkClassValues.getInstance(10000), 0, 600, 1, SHORT_HAUL_DOMESTIC, id = 2), 100, ECONOMY, false),
+        LinkConsideration(Shuttle(toAirportsList(1), toAirportsList(2), testAirline1, 50, LinkClassValues.getInstance(10000), id = 3), 100, ECONOMY, false))
 
       routes = PassengerSimulation.findShortestRoute(passengerGroup, toAirports, allAirportIds, links.asJava, Collections.emptyMap[Int, Int](), 3)
       routes.isDefinedAt(toAirportsList(2)).shouldBe(true)
@@ -84,9 +84,9 @@ class ShuttleSimulationSpec(_system: ActorSystem) extends TestKit(_system) with 
     }
     "find a route if there's a shuttle offered by alliance member".in {
       val links = List(
-        LinkConsideration(Link(fromAirport, toAirportsList(0), testAirline1, LinkClassValues.getInstance(100), 10000, LinkClassValues.getInstance(10000), 0, 600, 1, SHORT_HAUL_DOMESTIC), 100, ECONOMY, false),
-        LinkConsideration(Link(toAirportsList(0), toAirportsList(1), testAirline1, LinkClassValues.getInstance(100), 10000, LinkClassValues.getInstance(10000), 0, 600, 1, SHORT_HAUL_DOMESTIC), 100, ECONOMY, false),
-        LinkConsideration(Shuttle(toAirportsList(1), toAirportsList(2), testAirline2, 50, LinkClassValues.getInstance(10000)), 100, ECONOMY, false)) //shuttle by alliance member
+        LinkConsideration(Link(fromAirport, toAirportsList(0), testAirline1, LinkClassValues.getInstance(100), 10000, LinkClassValues.getInstance(10000), 0, 600, 1, SHORT_HAUL_DOMESTIC, id = 1), 100, ECONOMY, false),
+        LinkConsideration(Link(toAirportsList(0), toAirportsList(1), testAirline1, LinkClassValues.getInstance(100), 10000, LinkClassValues.getInstance(10000), 0, 600, 1, SHORT_HAUL_DOMESTIC, id = 2), 100, ECONOMY, false),
+        LinkConsideration(Shuttle(toAirportsList(1), toAirportsList(2), testAirline2, 50, LinkClassValues.getInstance(10000), id = 3), 100, ECONOMY, false)) //shuttle by alliance member
       
       val routes = PassengerSimulation.findShortestRoute(passengerGroup, toAirports, allAirportIds, links.asJava, Map(testAirline1.id -> 1, testAirline2.id -> 1).asJava, 3)
       routes.isDefinedAt(toAirportsList(2)).shouldBe(true)
@@ -96,27 +96,56 @@ class ShuttleSimulationSpec(_system: ActorSystem) extends TestKit(_system) with 
     }
     "find no route if there's a shuttle offered by different airline".in {
       val links = List(
-        LinkConsideration(Link(fromAirport, toAirportsList(0), testAirline1, LinkClassValues.getInstance(100), 10000, LinkClassValues.getInstance(10000), 0, 600, 1, SHORT_HAUL_DOMESTIC), 100, ECONOMY, false),
-        LinkConsideration(Link(toAirportsList(0), toAirportsList(1), testAirline1, LinkClassValues.getInstance(100), 10000, LinkClassValues.getInstance(10000), 0, 600, 1, SHORT_HAUL_DOMESTIC), 100, ECONOMY, false),
-        LinkConsideration(Shuttle(toAirportsList(1), toAirportsList(2), testAirline2, 50, LinkClassValues.getInstance(10000)), 100, ECONOMY, false)) //shuttle by different airline
+        LinkConsideration(Link(fromAirport, toAirportsList(0), testAirline1, LinkClassValues.getInstance(100), 10000, LinkClassValues.getInstance(10000), 0, 600, 1, SHORT_HAUL_DOMESTIC, id = 1), 100, ECONOMY, false),
+        LinkConsideration(Link(toAirportsList(0), toAirportsList(1), testAirline1, LinkClassValues.getInstance(100), 10000, LinkClassValues.getInstance(10000), 0, 600, 1, SHORT_HAUL_DOMESTIC, id = 2), 100, ECONOMY, false),
+        LinkConsideration(Shuttle(toAirportsList(1), toAirportsList(2), testAirline2, 50, LinkClassValues.getInstance(10000), id = 3), 100, ECONOMY, false)) //shuttle by different airline
 
       val routes = PassengerSimulation.findShortestRoute(passengerGroup, toAirports, allAirportIds, links.asJava, Collections.emptyMap[Int, Int](), 3)
       routes.isDefinedAt(toAirportsList(2)).shouldBe(false)
     }
-    "find no route if there's a shuttle offered by different alliance".in {
+    "find no route if there's a shuttle offered by different alliance (last link shuttle)".in {
       val links = List(
-        LinkConsideration(Link(fromAirport, toAirportsList(0), testAirline1, LinkClassValues.getInstance(100), 10000, LinkClassValues.getInstance(10000), 0, 600, 1, SHORT_HAUL_DOMESTIC), 100, ECONOMY, false),
-        LinkConsideration(Link(toAirportsList(0), toAirportsList(1), testAirline1, LinkClassValues.getInstance(100), 10000, LinkClassValues.getInstance(10000), 0, 600, 1, SHORT_HAUL_DOMESTIC), 100, ECONOMY, false),
-        LinkConsideration(Shuttle(toAirportsList(1), toAirportsList(2), testAirline2, 50, LinkClassValues.getInstance(10000)), 100, ECONOMY, false)) //shuttle by different airline
+        LinkConsideration(Link(fromAirport, toAirportsList(0), testAirline1, LinkClassValues.getInstance(100), 10000, LinkClassValues.getInstance(10000), 0, 600, 1, SHORT_HAUL_DOMESTIC, id = 1), 100, ECONOMY, false),
+        LinkConsideration(Link(toAirportsList(0), toAirportsList(1), testAirline1, LinkClassValues.getInstance(100), 10000, LinkClassValues.getInstance(10000), 0, 600, 1, SHORT_HAUL_DOMESTIC, id = 2), 100, ECONOMY, false),
+        LinkConsideration(Shuttle(toAirportsList(1), toAirportsList(2), testAirline2, 50, LinkClassValues.getInstance(10000), id = 3), 100, ECONOMY, false)) //shuttle by different airline
 
       val routes = PassengerSimulation.findShortestRoute(passengerGroup, toAirports, allAirportIds, links.asJava, Map(testAirline1.id -> 1, testAirline2.id -> 2).asJava, 3)
       routes.isDefinedAt(toAirportsList(2)).shouldBe(false)
     }
 
+    "find no route if there's a shuttle offered by different alliance (first link shuttle)".in {
+      val links = List(
+        LinkConsideration(Shuttle(fromAirport, toAirportsList(0), testAirline2, 50, LinkClassValues.getInstance(10000), id = 1), 100, ECONOMY, false), //shuttle by different airline
+        LinkConsideration(Link(toAirportsList(0), toAirportsList(1), testAirline1, LinkClassValues.getInstance(100), 10000, LinkClassValues.getInstance(10000), 0, 600, 1, SHORT_HAUL_DOMESTIC, id = 2), 100, ECONOMY, false))
+
+      val routes = PassengerSimulation.findShortestRoute(passengerGroup, toAirports, allAirportIds, links.asJava, Map(testAirline1.id -> 1, testAirline2.id -> 2).asJava, 3)
+      routes.isDefinedAt(toAirportsList(1)).shouldBe(false)
+    }
+    "find no route if there's a shuttle offered by both airlines but other airline is cheaper (first link shuttle)".in {
+      val links = List(
+        LinkConsideration(Shuttle(fromAirport, toAirportsList(0), testAirline1, 50, LinkClassValues.getInstance(10000), id = 1), 100, ECONOMY, false), //shuttle by current airline 1 but more expensive
+        LinkConsideration(Link(toAirportsList(0), toAirportsList(1), testAirline1, LinkClassValues.getInstance(100), 10000, LinkClassValues.getInstance(10000), 0, 600, 1, SHORT_HAUL_DOMESTIC, id = 2), 100, ECONOMY, false),
+        LinkConsideration(Shuttle(fromAirport, toAirportsList(0), testAirline2, 50, LinkClassValues.getInstance(10000), id = 3), 50, ECONOMY, false)) //shuttle by different airline 2 but cheaper
+
+
+      val routes = PassengerSimulation.findShortestRoute(passengerGroup, toAirports, allAirportIds, links.asJava, Map(testAirline1.id -> 1, testAirline2.id -> 2).asJava, 3)
+      routes.isDefinedAt(toAirportsList(1)).shouldBe(false)
+    }
+    "find a route if there's a shuttle offered by both airlines but current airline is cheaper (first link shuttle)".in {
+      val links = List(
+        LinkConsideration(Shuttle(fromAirport, toAirportsList(0), testAirline2, 50, LinkClassValues.getInstance(10000), id = 1), 100, ECONOMY, false), //shuttle by other airline 2 but more expensive
+        LinkConsideration(Link(toAirportsList(0), toAirportsList(1), testAirline1, LinkClassValues.getInstance(100), 10000, LinkClassValues.getInstance(10000), 0, 600, 1, SHORT_HAUL_DOMESTIC, id = 2), 100, ECONOMY, false),
+        LinkConsideration(Shuttle(fromAirport, toAirportsList(0), testAirline1, 50, LinkClassValues.getInstance(10000), id = 3), 50, ECONOMY, false)) //shuttle by current airline 1 but cheaper
+
+
+      val routes = PassengerSimulation.findShortestRoute(passengerGroup, toAirports, allAirportIds, links.asJava, Map(testAirline1.id -> 1, testAirline2.id -> 2).asJava, 3)
+      routes.isDefinedAt(toAirportsList(1)).shouldBe(true)
+    }
+
     "direct flight more preferable than shuttle".in {
-      val links = List(LinkConsideration(Shuttle(fromAirport, toAirportsList(0), testAirline1, 50, LinkClassValues.getInstance(10000)), 100, ECONOMY, false),
-        LinkConsideration(Link(toAirportsList(0), toAirportsList(1), testAirline1, LinkClassValues.getInstance(100), 10000, LinkClassValues.getInstance(10000), 0, 600, 1, SHORT_HAUL_DOMESTIC), 100, ECONOMY, false),
-        LinkConsideration(Link(fromAirport, toAirportsList(1), testAirline1, LinkClassValues.getInstance(100), 10000, LinkClassValues.getInstance(10000), 0, 600, 1, SHORT_HAUL_DOMESTIC), 100, ECONOMY, false))
+      val links = List(LinkConsideration(Shuttle(fromAirport, toAirportsList(0), testAirline1, 50, LinkClassValues.getInstance(10000), id = 1), 100, ECONOMY, false),
+        LinkConsideration(Link(toAirportsList(0), toAirportsList(1), testAirline1, LinkClassValues.getInstance(100), 10000, LinkClassValues.getInstance(10000), 0, 600, 1, SHORT_HAUL_DOMESTIC, id = 2), 100, ECONOMY, false),
+        LinkConsideration(Link(fromAirport, toAirportsList(1), testAirline1, LinkClassValues.getInstance(100), 10000, LinkClassValues.getInstance(10000), 0, 600, 1, SHORT_HAUL_DOMESTIC, id = 3), 100, ECONOMY, false))
 
       val routes = PassengerSimulation.findShortestRoute(passengerGroup, toAirports, allAirportIds, links.asJava, Collections.emptyMap[Int, Int](), 3)
       routes.isDefinedAt(toAirportsList(1)).shouldBe(true)
@@ -124,10 +153,10 @@ class ShuttleSimulationSpec(_system: ActorSystem) extends TestKit(_system) with 
       route.links.size.shouldBe(1) //should take the direct flight only
     }
     "use direct route even though it's more expensive as connection flight is not frequent enough".in {
-     val cheapLinks = List(LinkConsideration(Link(fromAirport, toAirportsList(0), testAirline1, LinkClassValues.getInstance(100), 10000, LinkClassValues.getInstance(10000), 0, duration = 200, frequency = 1, SHORT_HAUL_DOMESTIC), 400, ECONOMY, false),
-          LinkConsideration(Link(toAirportsList(0), toAirportsList(1), testAirline1, LinkClassValues.getInstance(100), 10000, LinkClassValues.getInstance(10000), 0, duration = 200, frequency = 1, SHORT_HAUL_DOMESTIC), 400, ECONOMY, false),
-          LinkConsideration(Link(toAirportsList(1), toAirportsList(2), testAirline1, LinkClassValues.getInstance(100), 10000, LinkClassValues.getInstance(10000), 0, duration = 200, frequency = 1, SHORT_HAUL_DOMESTIC), 400, ECONOMY, false))
-     val expensiveLink = LinkConsideration(Link(fromAirport, toAirportsList(2), testAirline1, LinkClassValues.getInstance(100), 10000, LinkClassValues.getInstance(10000), 0, duration = 600, frequency = 1, SHORT_HAUL_DOMESTIC), 1400, ECONOMY, false)
+     val cheapLinks = List(LinkConsideration(Link(fromAirport, toAirportsList(0), testAirline1, LinkClassValues.getInstance(100), 10000, LinkClassValues.getInstance(10000), 0, duration = 200, frequency = 1, SHORT_HAUL_DOMESTIC, id = 1), 400, ECONOMY, false),
+          LinkConsideration(Link(toAirportsList(0), toAirportsList(1), testAirline1, LinkClassValues.getInstance(100), 10000, LinkClassValues.getInstance(10000), 0, duration = 200, frequency = 1, SHORT_HAUL_DOMESTIC, id = 2), 400, ECONOMY, false),
+          LinkConsideration(Link(toAirportsList(1), toAirportsList(2), testAirline1, LinkClassValues.getInstance(100), 10000, LinkClassValues.getInstance(10000), 0, duration = 200, frequency = 1, SHORT_HAUL_DOMESTIC, id = 3), 400, ECONOMY, false))
+     val expensiveLink = LinkConsideration(Link(fromAirport, toAirportsList(2), testAirline1, LinkClassValues.getInstance(100), 10000, LinkClassValues.getInstance(10000), 0, duration = 600, frequency = 1, SHORT_HAUL_DOMESTIC, id = 4), 1400, ECONOMY, false)
      val allLinks =  expensiveLink :: cheapLinks
       val routes = PassengerSimulation.findShortestRoute(passengerGroup, toAirports, allAirportIds, allLinks.asJava, Collections.emptyMap[Int, Int](), 3)
       routes.isDefinedAt(toAirportsList(2)).shouldBe(true)
@@ -138,9 +167,9 @@ class ShuttleSimulationSpec(_system: ActorSystem) extends TestKit(_system) with 
   }
   "findAllRoutes".must {
     "find routes if there are valid links".in {
-      val links = List(Link(fromAirport, toAirportsList(0), testAirline1, LinkClassValues.getInstance(100, 100, 100), 10000, LinkClassValues.getInstance(10000, 10000, 10000), 0, 600, 1, SHORT_HAUL_DOMESTIC),
-                      Shuttle(toAirportsList(0), toAirportsList(1), testAirline1, 50, LinkClassValues.getInstance(10000, 0, 0)),
-                      Link(toAirportsList(1), toAirportsList(2), testAirline1, LinkClassValues.getInstance(100, 100, 100), 10000, LinkClassValues.getInstance(10000, 10000, 10000), 0, 600, 1, SHORT_HAUL_DOMESTIC))
+      val links = List(Link(fromAirport, toAirportsList(0), testAirline1, LinkClassValues.getInstance(100, 100, 100), 10000, LinkClassValues.getInstance(10000, 10000, 10000), 0, 600, 1, SHORT_HAUL_DOMESTIC, id = 1),
+                      Shuttle(toAirportsList(0), toAirportsList(1), testAirline1, 50, LinkClassValues.getInstance(10000, 0, 0), id = 2),
+                      Link(toAirportsList(1), toAirportsList(2), testAirline1, LinkClassValues.getInstance(100, 100, 100), 10000, LinkClassValues.getInstance(10000, 10000, 10000), 0, 600, 1, SHORT_HAUL_DOMESTIC, id = 3))
       
       val economyPassengerGroup = PassengerGroup(fromAirport, AppealPreference(fromAirport, ECONOMY, loungeLevelRequired = 0, loyaltyRatio = 1, 0), PassengerType.BUSINESS)
       val businessPassengerGroup = PassengerGroup(fromAirport, AppealPreference(fromAirport, BUSINESS, loungeLevelRequired = 0, loyaltyRatio = 1, 0), PassengerType.BUSINESS)


### PR DESCRIPTION
//for example on first iteration, there is F0, T1 and T2. If there are links:
      // Link Consideration 1 : Airline A, F0 -> T1, cost 50
      // Link Consideration 2 : Airline A, T1 -> T2, cost 50
      // Link Consideration 3 : Airline B, F0 -> T1, cost 40
      //If we do NOT use a clone and lookup the current predecessorMap, from F0
      // It will be:
      // 1. Process Link Consideration 1, predecessorMap: T1 -> (Link 1, 50)
      // 2. Process Link Consideration 2, predecessorMap: T1 -> (Link 1, 50), T2 -> (Link 2, 50 + 50 + Connection cost of SAME airline)
      // 3. Process Link Consideration 3, predecessorMap: T1 -> (Link 3, 40), T2 -> (Link 2, 50 + 50 + Connection cost of SAME airline)
      // At the end it will be wrong as solution for route from F0 to T2, will be Link 3 and Link 2 while the final cost is incorrect
      // This also create the shuttle from other alliance problem
      //The fix for this is never use the current predecessorMap for lookup, instead, use the previous map