### PR TITLE
Income boost changes and demand adjustment (back to 2.0 equation)

### DIFF
--- a/airline-data/src/main/scala/com/patson/DemandGenerator.scala
+++ b/airline-data/src/main/scala/com/patson/DemandGenerator.scala
@@ -22,10 +22,10 @@ object DemandGenerator {
 //  implicit val materializer = FlowMaterializer()
   private[this] val FIRST_CLASS_INCOME_MIN = 15000
   private[this] val FIRST_CLASS_INCOME_MAX = 100_000
-  private[this] val FIRST_CLASS_PERCENTAGE_MAX = Map(PassengerType.BUSINESS -> 0.06, PassengerType.TOURIST -> 0.02, PassengerType.OLYMPICS -> 0.03) //max 8% first (Business passenger), 2% first (Tourist)
+  private[this] val FIRST_CLASS_PERCENTAGE_MAX = Map(PassengerType.BUSINESS -> 0.08, PassengerType.TOURIST -> 0.02, PassengerType.OLYMPICS -> 0.03) //max 8% first (Business passenger), 2% first (Tourist)
   private[this] val BUSINESS_CLASS_INCOME_MIN = 5000
   private[this] val BUSINESS_CLASS_INCOME_MAX = 100_000
-  private[this] val BUSINESS_CLASS_PERCENTAGE_MAX = Map(PassengerType.BUSINESS -> 0.25, PassengerType.TOURIST -> 0.10, PassengerType.OLYMPICS -> 0.15) //max 30% business (Business passenger), 10% business (Tourist)
+  private[this] val BUSINESS_CLASS_PERCENTAGE_MAX = Map(PassengerType.BUSINESS -> 0.3, PassengerType.TOURIST -> 0.10, PassengerType.OLYMPICS -> 0.15) //max 30% business (Business passenger), 10% business (Tourist)
   
   val MIN_DISTANCE = 50
   
@@ -124,7 +124,7 @@ object DemandGenerator {
       val lowIncomeThreshold = Country.LOW_INCOME_THRESHOLD + 10_000 //due to a bug in v2, we need to increase this a bit to avoid demand collapse in low income countries
 
       val fromAirportAdjustedIncome : Double = if (fromAirport.income > Country.HIGH_INCOME_THRESHOLD) { //to make high income airport a little bit less overpowered
-        Country.HIGH_INCOME_THRESHOLD + (fromAirport.income - Country.HIGH_INCOME_THRESHOLD) / 10
+        Country.HIGH_INCOME_THRESHOLD + (fromAirport.income - Country.HIGH_INCOME_THRESHOLD) / 3
       } else if (fromAirport.income < lowIncomeThreshold) { //to make low income airport a bit stronger
         val delta = lowIncomeThreshold - fromAirport.income
         lowIncomeThreshold - delta * 0.3 //so a 0 income country will be boosted to 21000, a 10000 income country will be boosted to 24000

--- a/airline-data/src/main/scala/com/patson/model/Airport.scala
+++ b/airline-data/src/main/scala/com/patson/model/Airport.scala
@@ -47,7 +47,7 @@ case class Airport(iata : String, icao : String, name : String, latitude : Doubl
     case Some(boosts) => boosts.map(_.value).sum
     case None => 0
   }) + airlineBases.values.map { airlineBase =>
-    airlineBase.specializations.filter(_ == POWERHOUSE).map(_.asInstanceOf[PowerhouseSpecialization].incomeLevelBoost).sum
+    airlineBase.specializations.filter(_ == POWERHOUSE).map(_.asInstanceOf[PowerhouseSpecialization].incomeLevelBoost(this)).sum
   }.sum
   lazy val incomeLevel = baseIncomeLevel + incomeLevelBoost
   lazy val income = if (incomeLevelBoost == 0) baseIncome else Computation.fromIncomeLevel(incomeLevel) //have to deduce from income level (after boost)

--- a/airline-data/src/main/scala/com/patson/model/AirportAsset.scala
+++ b/airline-data/src/main/scala/com/patson/model/AirportAsset.scala
@@ -108,7 +108,7 @@ object AirportAssetType extends Enumeration {
         override val label = "Sport Arena"
         override val constructionDuration : Int = 2 * 52
         //override val descriptions = List(s"Sport Arena")
-        override val baseBoosts : List[AirportBoost] = List(AirportBoost(INCOME, 0.50))
+        override val baseBoosts : List[AirportBoost] = List(AirportBoost(INCOME, 0.1))
         override val baseCost : Long = 200_000_000
         override val baseRequirement : Int = 3
 
@@ -120,7 +120,7 @@ object AirportAssetType extends Enumeration {
         override val label = "Shopping Mall"
         override val constructionDuration : Int = 3 * 52
         //override val descriptions = List(s"Shopping Mall")
-        override val baseBoosts : List[AirportBoost] = List(AirportBoost(INCOME, 1))
+        override val baseBoosts : List[AirportBoost] = List(AirportBoost(INCOME, 0.2))
         override val baseCost : Long = 800_000_000
         override val baseRequirement : Int = 5
 
@@ -181,7 +181,7 @@ object AirportAssetType extends Enumeration {
     case class ScienceParkAssetType() extends RentalAssetType {
         override val label = "Science Park"
         override val constructionDuration : Int = 6 * 52
-        override val baseBoosts : List[AirportBoost] = List(AirportBoost(INCOME, 2), AirportBoost(FINANCIAL_HUB, 5), AirportBoost(POPULATION, 50000))
+        override val baseBoosts : List[AirportBoost] = List(AirportBoost(INCOME, 0.5), AirportBoost(FINANCIAL_HUB, 5), AirportBoost(POPULATION, 50000))
         override val baseCost : Long = 5_000_000_000L
         override val baseRequirement : Int = 12
 
@@ -212,7 +212,7 @@ object AirportAssetType extends Enumeration {
     case class TravelAgencyAssetType() extends AirportAssetType {
         override val label = "Travel Agency"
         override val constructionDuration : Int = 1 * 52
-        override val baseBoosts : List[AirportBoost] = List(AirportBoost(INCOME, 0.30))
+        override val baseBoosts : List[AirportBoost] = List(AirportBoost(INCOME, 0.05))
         override val baseCost : Long = 100_000_000
         override val baseRequirement : Int = 3
 
@@ -222,7 +222,7 @@ object AirportAssetType extends Enumeration {
     case class GameArcadeAssetType() extends AirportAssetType {
         override val label = "Game Arcade"
         override val constructionDuration : Int = 1 * 52
-        override val baseBoosts : List[AirportBoost] = List(AirportBoost(INCOME, 0.20))
+        override val baseBoosts : List[AirportBoost] = List(AirportBoost(INCOME, 0.02))
         override val baseCost : Long = 30_000_000
         override val baseRequirement : Int = 3
 
@@ -232,7 +232,7 @@ object AirportAssetType extends Enumeration {
     case class CinemaAssetType() extends AdmissionAssetType {
         override val label = "Cinema"
         override val constructionDuration : Int = 2 * 52
-        override val baseBoosts : List[AirportBoost] = List(AirportBoost(INCOME, 0.50))
+        override val baseBoosts : List[AirportBoost] = List(AirportBoost(INCOME, 0.05))
         override val baseCost : Long = 50_000_000
         override val baseRequirement : Int = 3
 
@@ -242,7 +242,7 @@ object AirportAssetType extends Enumeration {
     case class InnAssetType() extends HotelAssetType {
         override val label = "Inn"
         override val constructionDuration : Int = 1 * 52
-        override val baseBoosts : List[AirportBoost] = List(AirportBoost(INCOME, 0.30))
+        override val baseBoosts : List[AirportBoost] = List(AirportBoost(INCOME, 0.02))
         override val baseCost : Long = 10_000_000
         override val baseRequirement : Int = 1
 
@@ -252,7 +252,7 @@ object AirportAssetType extends Enumeration {
     case class GolfCourseAssetType() extends AdmissionAssetType {
         override val label = "Golf Course"
         override val constructionDuration : Int = 4 * 52
-        override val baseBoosts : List[AirportBoost] = List(AirportBoost(INCOME, 0.5))
+        override val baseBoosts : List[AirportBoost] = List(AirportBoost(INCOME, 0.1))
         override val baseCost : Long = 400_000_000
         override val baseRequirement : Int = 5
 
@@ -262,7 +262,7 @@ object AirportAssetType extends Enumeration {
     case class OfficeBuilding1AssetType() extends RentalAssetType {
         override val label = "Office Building I"
         override val constructionDuration : Int = 3 * 52
-        override val baseBoosts : List[AirportBoost] = List(AirportBoost(INCOME, 0.70))
+        override val baseBoosts : List[AirportBoost] = List(AirportBoost(INCOME, 0.1))
         override val baseCost : Long = 300_000_000
         override val baseRequirement : Int = 7
 
@@ -272,7 +272,7 @@ object AirportAssetType extends Enumeration {
     case class AverageHotelAssetType() extends HotelAssetType {
         override val label = "Hotel"
         override val constructionDuration : Int = 2 * 52
-        override val baseBoosts : List[AirportBoost] = List(AirportBoost(INCOME, 0.50))
+        override val baseBoosts : List[AirportBoost] = List(AirportBoost(INCOME, 0.05))
         override val baseCost : Long = 100_000_000
         override val baseRequirement : Int = 5
 
@@ -282,7 +282,7 @@ object AirportAssetType extends Enumeration {
     case class OfficeBuilding2AssetType() extends RentalAssetType {
         override val label = "Office Building II"
         override val constructionDuration : Int = 3 * 52
-        override val baseBoosts : List[AirportBoost] = List(AirportBoost(INCOME, 1))
+        override val baseBoosts : List[AirportBoost] = List(AirportBoost(INCOME, 0.12))
         override val baseCost : Long = 500_000_000
         override val baseRequirement : Int = 9
 
@@ -292,7 +292,7 @@ object AirportAssetType extends Enumeration {
     case class RestaurantAssetType() extends AirportAssetType {
         override val label = "Restaurant"
         override val constructionDuration : Int = 1 * 52
-        override val baseBoosts : List[AirportBoost] = List(AirportBoost(INCOME, 0.30))
+        override val baseBoosts : List[AirportBoost] = List(AirportBoost(INCOME, 0.02))
         override val baseCost : Long = 10_000_000
         override val baseRequirement : Int = 1
 
@@ -302,7 +302,7 @@ object AirportAssetType extends Enumeration {
     case class OfficeBuilding3AssetType() extends RentalAssetType {
         override val label = "Office Building III"
         override val constructionDuration : Int = 4 * 52
-        override val baseBoosts : List[AirportBoost] = List(AirportBoost(INCOME, 1.20))
+        override val baseBoosts : List[AirportBoost] = List(AirportBoost(INCOME, 0.2))
         override val baseCost : Long = 1_000_000_000
         override val baseRequirement : Int = 11
 
@@ -312,7 +312,7 @@ object AirportAssetType extends Enumeration {
     case class LuxuriousHotelAssetType() extends HotelAssetType {
         override val label = "Luxurious Hotel"
         override val constructionDuration : Int = 3 * 52
-        override val baseBoosts : List[AirportBoost] = List(AirportBoost(INCOME, 0.80))
+        override val baseBoosts : List[AirportBoost] = List(AirportBoost(INCOME, 0.1))
         override val baseCost : Long = 500_000_000
         override val baseRequirement : Int = 7
 
@@ -322,7 +322,7 @@ object AirportAssetType extends Enumeration {
     case class OfficeBuilding4AssetType() extends RentalAssetType {
         override val label = "Office Building IV"
         override val constructionDuration : Int = 5 * 52
-        override val baseBoosts : List[AirportBoost] = List(AirportBoost(INCOME, 1.50))
+        override val baseBoosts : List[AirportBoost] = List(AirportBoost(INCOME, 0.25))
         override val baseCost : Long = 1_500_000_000
         override val baseRequirement : Int = 12
 
@@ -451,14 +451,8 @@ abstract class AirportAsset() extends IdObject{
         case Some(_) => //need to create a new list
             blueprint.assetType.baseBoosts.map { baseBoost =>
                 baseBoost.boostType match {
-                    case AirportBoostType.INCOME => //assuming that it was defined for level 40, up to triple the effect if income level = 0, half the affect for level 60
-                        val multiplier =
-                            if (airport.baseIncomeLevel < 40) {
-                                (1 + (40 - airport.baseIncomeLevel) / 20)
-                            } else {
-                                1 - Math.min(0.5, (airport.baseIncomeLevel - 40) / 40)
-                            }
-                        baseBoost.copy(value = ((baseBoost.value * multiplier) * 100).toInt / 100.0) //keep 2 decimal
+                    case AirportBoostType.INCOME =>
+                        baseBoost.copy(value = Computation.computeIncomeLevelBoostFromLevel(airport.baseIncome, baseBoost.value)) //income level boost need adjustments for high income country
                     case _ => baseBoost
                 }
             }

--- a/airline-data/src/main/scala/com/patson/model/Computation.scala
+++ b/airline-data/src/main/scala/com/patson/model/Computation.scala
@@ -143,6 +143,38 @@ object Computation {
     (Math.pow(Math.E, incomeLevel * Math.log(1.1)) * 500).toInt
   }
 
+  def computeIncomeLevelBoostFromPercentage(baseIncome : Int, minIncomeBoost : Int, boostPercentage : Int) = {
+    val incomeIncrement = baseIncome * boostPercentage / 100
+    val incomeBoost = Math.max(minIncomeBoost, incomeIncrement)
+
+    //10% would always be 1, but cannot make assumption of our income level calculation tho...
+    val baseIncomeLevel = getIncomeLevel(baseIncome)
+    BigDecimal(Computation.getIncomeLevel(baseIncome + incomeBoost) - baseIncomeLevel).setScale(2, BigDecimal.RoundingMode.HALF_UP).toDouble
+  }
+
+  /**
+    * For low income base, use the boost level (which is MAX boost). For higher income base, down adjust it to certain
+    * percentage
+    * @param baseIncome
+    * @param boostLevel
+    * @return
+    */
+  def computeIncomeLevelBoostFromLevel(baseIncome : Int, boostLevel : Double) = {
+    val newIncomeLevel = getIncomeLevel(baseIncome) + boostLevel
+    val incomeIncrement = fromIncomeLevel(newIncomeLevel) - baseIncome
+    val maxIncomeBoost = (boostLevel * 10_000).toInt //a bit arbitrary
+    val minIncomeBoost = (boostLevel * 2_500).toInt
+    val finalBoostLevel =
+      if (incomeIncrement < minIncomeBoost) {
+        getIncomeLevel(baseIncome + minIncomeBoost) - getIncomeLevel(baseIncome)
+      } else if (incomeIncrement <= maxIncomeBoost) {
+        boostLevel
+      } else {
+        getIncomeLevel(baseIncome + maxIncomeBoost) - getIncomeLevel(baseIncome)
+      }
+
+    BigDecimal(finalBoostLevel).setScale(2, BigDecimal.RoundingMode.HALF_UP).toDouble
+  }
 
   
   def getLinkCreationCost(from : Airport, to : Airport) : Int = {

--- a/airline-web/app/controllers/AirlineApplication.scala
+++ b/airline-web/app/controllers/AirlineApplication.scala
@@ -983,7 +983,8 @@ class AirlineApplication @Inject()(cc: ControllerComponents) extends AbstractCon
   }
 
   def getBaseSpecializationInfo(airlineId: Int, airportId : Int) = AuthenticatedAirline(airlineId) { request =>
-    val base = AirportCache.getAirport(airportId, true).get.getAirlineBase(airlineId).get
+    val airport = AirportCache.getAirport(airportId, true).get
+    val base = airport.getAirlineBase(airlineId).get
     val activeSpecializations : List[AirlineBaseSpecialization.Value] = base.specializations
     val specializationByScaleRequirement : List[(Int, List[AirlineBaseSpecialization.Value])] = AirlineBaseSpecialization.values.toList.groupBy(_.scaleRequirement).toList.sortBy(_._1)
     val cooldown =
@@ -999,6 +1000,7 @@ class AirlineApplication @Inject()(cc: ControllerComponents) extends AbstractCon
       }
 
     var specializationJson = Json.arr()
+    implicit val specializationWrites = AirlineBaseSpecializationWrites(airport)
 
     specializationByScaleRequirement.foreach {
       case(scaleRequirement, specializations) =>

--- a/airline-web/app/controllers/package.scala
+++ b/airline-web/app/controllers/package.scala
@@ -284,12 +284,12 @@ package object controllers {
     }
   }
 
-  implicit object AirlineBaseSpecializationWrites extends OWrites[AirlineBaseSpecialization.Value] {
+  case class AirlineBaseSpecializationWrites(airport : Airport) extends OWrites[AirlineBaseSpecialization.Value] {
     override def writes(specialization : AirlineBaseSpecialization.Value) : JsObject = {
       Json.obj(
         "id" -> specialization.toString,
         "label" -> specialization.label,
-        "descriptions" -> specialization.descriptions,
+        "descriptions" -> specialization.descriptions(airport),
       )
     }
   }


### PR DESCRIPTION
1. High income country demand resumed to v2.0 level across all classes with slight increase. For example HKG -> SFO in 2.0 it was 1160 / 326 / 69, in 2.1 after this change, it will be

1178 / 331 / 69
2. Base lvl 14 spec and asset will have income level boost calculated based on the income (a hidden value) of such airport. It will be % based to the income. However for lower income airport, there will be a "min boost", so for low income country. +income level assets are getting a boost as a result
3. Also because of point 2. Income level boost for rich country will be reduced. Sorry it was an oversight of me during v2.1 development