### PR TITLE
FOD's alliance rejection message suggestion

### DIFF
--- a/airline-web/app/controllers/AllianceApplication.scala
+++ b/airline-web/app/controllers/AllianceApplication.scala
@@ -610,9 +610,11 @@ class AllianceApplication @Inject()(cc: ControllerComponents) extends AbstractCo
     val approvedMembers = alliance.members.filter(_.role != AllianceRole.APPLICANT)
     
     
-    var message = "";
+    var message = ""
+    var ok = true
     if (airline.getHeadQuarter.isEmpty) { 
       message =  "X: Airline does not have headquarters\n"
+      ok=false
     }
     else {
       message = "✓: Airline headquarters established\n"
@@ -620,6 +622,7 @@ class AllianceApplication @Inject()(cc: ControllerComponents) extends AbstractCo
     
     if (approvedMembers.size >= Alliance.MAX_MEMBER_COUNT) {
       message+="X: Alliance is full Remove an existing member first before applying\n"
+      ok=false
     }
     
     else{
@@ -631,6 +634,7 @@ class AllianceApplication @Inject()(cc: ControllerComponents) extends AbstractCo
     
     if (allAllianceHeadquarters.contains(airlineHeadquarters)) {
       message+="X: One of the alliance members already has Headquarters at " + getAirportText(airlineHeadquarters)) + "\n"
+      ok=false
     }
     
     else{
@@ -653,6 +657,7 @@ class AllianceApplication @Inject()(cc: ControllerComponents) extends AbstractCo
       }
        
       message+=" Remove overlapping bases first before applying\n"
+      ok=false
     }
     
     else {
@@ -663,11 +668,15 @@ class AllianceApplication @Inject()(cc: ControllerComponents) extends AbstractCo
        case Some(allianceMember) =>
          if (allianceMember.allianceId != alliance.id) {
            message+="X: Airline is already a member of another alliance " + "Leave " + AllianceCache.getAlliance(allianceMember.allianceId).get.name) "first before applying"
+           ok=false;
          }
        case None =>
            message+="✓: Airline not in another alliance"
      }
-    return message
+    if(ok) {
+      return None
+    }
+    return Some(message)
   }
   
   def getAirportText(airport : Airport) = {

--- a/airline-web/app/controllers/AllianceApplication.scala
+++ b/airline-web/app/controllers/AllianceApplication.scala
@@ -609,22 +609,35 @@ class AllianceApplication @Inject()(cc: ControllerComponents) extends AbstractCo
   def getApplyRejection(airline : Airline, alliance : Alliance) : Option[String] = {
     val approvedMembers = alliance.members.filter(_.role != AllianceRole.APPLICANT)
     
+    
+    var message = "";
     if (airline.getHeadQuarter.isEmpty) { 
-      return Some("Airline does not have headquarters")
+      message =  "X: Airline does not have headquarters\n"
+    }
+    else {
+      message = "✓: Airline headquarters established\n"
     }
     
     if (approvedMembers.size >= Alliance.MAX_MEMBER_COUNT) {
-      return Some("Alliance has reached max member size " + Alliance.MAX_MEMBER_COUNT + " already")
+      message+="X: Alliance is full. Remove an existing member first before applying\n"
     }
     
-    
+    else{
+      message+="✓: Alliance has available spot(s)\n"
+    }
     val allAllianceHeadquarters = approvedMembers.flatMap(_.airline.getHeadQuarter).map(_.airport)
 
     val airlineHeadquarters = airline.getHeadQuarter.get.airport
     
     if (allAllianceHeadquarters.contains(airlineHeadquarters)) {
-      return Some("One of the alliance members has Headquarters at " + getAirportText(airlineHeadquarters))
+      message+="X: One of the alliance members already has Headquarters at " + getAirportText(airlineHeadquarters)) + "\n"
     }
+    
+    else{
+      message+="✓: No Overlapping Headquarters\n"
+    }
+    
+      
     
     val allAllianceBases = approvedMembers.flatMap { _.airline.getBases().filter( !_.headquarter) }.map(_.airport)
     val airlineBases = airline.getBases.filter(!_.headquarter).map(_.airport) 
@@ -634,23 +647,27 @@ class AllianceApplication @Inject()(cc: ControllerComponents) extends AbstractCo
 //     println("YOURS " + airlineHeadquarters)
     
     if (!overlappingBases.isEmpty) {
-      var message = "Alliance members have overlapping airport bases: "
+      message += "Alliance members have overlapping airport bases: "
       overlappingBases.foreach { overlappingBase =>
         message += getAirportText(overlappingBase) + "; "
       }
        
-      return Some(message)
+      message+="\n"
+    }
+    
+    else {
+      message+="✓: Alliance members have no overlapping airport bases\n"
     }
     
      AllianceSource.loadAllianceMemberByAirline(airline) match {
        case Some(allianceMember) =>
          if (allianceMember.allianceId != alliance.id) {
-           return Some("Airline is already a member of another alliance " + AllianceCache.getAlliance(allianceMember.allianceId).get.name)
+           message+="X: Airline is already a member of another alliance " + AllianceCache.getAlliance(allianceMember.allianceId).get.name)
          }
        case None =>
-
+           message+="✓: Airline not in another alliance"
      }
-    return None
+    return message
   }
   
   def getAirportText(airport : Airport) = {

--- a/airline-web/app/controllers/AllianceApplication.scala
+++ b/airline-web/app/controllers/AllianceApplication.scala
@@ -619,7 +619,7 @@ class AllianceApplication @Inject()(cc: ControllerComponents) extends AbstractCo
     }
     
     if (approvedMembers.size >= Alliance.MAX_MEMBER_COUNT) {
-      message+="X: Alliance is full. Remove an existing member first before applying\n"
+      message+="X: Alliance is full Remove an existing member first before applying\n"
     }
     
     else{
@@ -652,7 +652,7 @@ class AllianceApplication @Inject()(cc: ControllerComponents) extends AbstractCo
         message += getAirportText(overlappingBase) + "; "
       }
        
-      message+=" Remove overlapping bases first\n"
+      message+=" Remove overlapping bases first before applying\n"
     }
     
     else {
@@ -662,7 +662,7 @@ class AllianceApplication @Inject()(cc: ControllerComponents) extends AbstractCo
      AllianceSource.loadAllianceMemberByAirline(airline) match {
        case Some(allianceMember) =>
          if (allianceMember.allianceId != alliance.id) {
-           message+="X: Airline is already a member of another alliance " + AllianceCache.getAlliance(allianceMember.allianceId).get.name)
+           message+="X: Airline is already a member of another alliance " + "Leave " + AllianceCache.getAlliance(allianceMember.allianceId).get.name) "first before applying"
          }
        case None =>
            message+="✓: Airline not in another alliance"

--- a/airline-web/app/controllers/AllianceApplication.scala
+++ b/airline-web/app/controllers/AllianceApplication.scala
@@ -652,7 +652,7 @@ class AllianceApplication @Inject()(cc: ControllerComponents) extends AbstractCo
         message += getAirportText(overlappingBase) + "; "
       }
        
-      message+="\n"
+      message+=" Remove overlapping bases first\n"
     }
     
     else {

--- a/airline-web/app/controllers/AllianceApplication.scala
+++ b/airline-web/app/controllers/AllianceApplication.scala
@@ -656,7 +656,7 @@ class AllianceApplication @Inject()(cc: ControllerComponents) extends AbstractCo
         message += getAirportText(overlappingBase) + "; "
       }
        
-      message+=" Remove overlapping bases first before applying\n"
+      message+="X: Remove overlapping bases first before applying\n"
       ok=false
     }
     


### PR DESCRIPTION
Instead of showing a Cannot Join Alliance error for applying to other alliances if you're already in one, show the following checklist:

✅ Not in another alliance | ❌ In another alliance. Leave My First Alliance first before applying. ✅ No overlapping bases | ❌ Following bases overlap: JFK JFK. Remove overlapping bases first before applying.  ✅ Alliance has open spots | ❌ Alliance is full. Remove an existing member first before applying.