### PR TITLE
Fixed super low price ticket might affect network in big cities

### DIFF
--- a/airline-data/src/main/scala/com/patson/PassengerSimulation.scala
+++ b/airline-data/src/main/scala/com/patson/PassengerSimulation.scala
@@ -13,6 +13,7 @@ import scala.collection.mutable
 import scala.collection.mutable.{ListBuffer, Set}
 import scala.util.Random
 import scala.collection.parallel.CollectionConverters._
+import  scala.jdk.CollectionConverters._
 
 object PassengerSimulation {
 
@@ -65,8 +66,8 @@ object PassengerSimulation {
   case class PassengerConsumptionResult(consumptionByRoutes : Map[(PassengerGroup, Airport, Route), Int], missedDemand : Map[(PassengerGroup, Airport), Int])
 
   def passengerConsume[T <: Transport](demand : List[(PassengerGroup, Airport, Int)], links : List[T]) : PassengerConsumptionResult = {
-    val consumptionResult = ListBuffer[(PassengerGroup, Airport, Int, Route)]()
-    val missedDemandChunks = ListBuffer[(PassengerGroup, Airport, Int)]()
+    val consumptionResult = Collections.synchronizedList(new ArrayList[(PassengerGroup, Airport, Int, Route)]())
+    val missedDemandChunks = Collections.synchronizedList(new ArrayList[(PassengerGroup, Airport, Int)]())
     val consumptionCycleMax = 10; //try and rebuild routes 10 times
     var consumptionCycleCount = 0;
     //start consumption cycles
@@ -88,7 +89,7 @@ object PassengerSimulation {
       val (passengerGroup, toAirport, chunkSize) = demandChunk
       val isConnected = activeAirportIds.contains(passengerGroup.fromAirport.id) && activeAirportIds.contains(toAirport.id)
       if (!isConnected) {
-        missedDemandChunks.append(demandChunk)
+        missedDemandChunks.add(demandChunk)
       }
       isConnected
     }).sortWith((entry1, entry2) =>
@@ -151,18 +152,29 @@ object PassengerSimulation {
         if (consumptionCycleCount < 3) 4
         else if (consumptionCycleCount < 6) 5
         else 6
-       val allRoutesMap = findAllRoutes(requiredRoutes.toMap, availableLinks, activeAirportIds, PassengerSimulation.countryOpenness, establishedAllianceIdByAirlineId, Some(externalCostModifier), iterationCount)
+      val allRoutesMap = mutable.HashMap[PassengerGroup, Map[Airport, Route]]()
 
        //start consuming routes
-       println()
-       print("Start to go through demand chunks and comsume...nom nom nom...")
+//       println()
+//       print("Start to go through demand chunks and comsume...nom nom nom...")
 
        //we want to randomize the order and go chunk by chunk as we want to evenly/randomly distribute seats to each PassengerGroup
-       val remainingDemandChunks = ListBuffer[(PassengerGroup, Airport, Int)]()
+       val remainingDemandChunks = Collections.synchronizedList(new ArrayList[(PassengerGroup, Airport, Int)]())
 
-       demandChunks.foreach {
+      println("Total passenger groups : " + requiredRoutes.size)
+      println(s"Iteration count : $iterationCount")
+      val counter = new AtomicInteger(0)
+      val progressCount = new AtomicInteger(0)
+      val progressChunk = requiredRoutes.size / 100
+
+       demandChunks.par.foreach {
          case (passengerGroup, toAirport, chunkSize) =>
-           allRoutesMap.get(passengerGroup).foreach { toAirportRouteMap =>
+           var hasComputedRouteMap = false
+           val toAirportRouteMap = allRoutesMap.getOrElseUpdate(passengerGroup,  {
+             hasComputedRouteMap = true
+             findRoutesByPassengerGroup(passengerGroup, requiredRoutes(passengerGroup), availableLinks, activeAirportIds, PassengerSimulation.countryOpenness, establishedAllianceIdByAirlineId, Some(externalCostModifier), iterationCount)
+           })
+           //allRoutesMap.get(passengerGroup).foreach { toAirportRouteMap =>
 //             if (!toAirportRouteMap.isEmpty) {
 //               println("to airport route map" + toAirportRouteMap)
 //             }
@@ -183,68 +195,83 @@ object PassengerSimulation {
                  val rejection = getRouteRejection(pickedRoute, fromAirport, toAirport, passengerGroup.preference.preferredLinkClass)
                  rejection match {
                    case None =>
-                     val consumptionSize = pickedRoute.links.foldLeft(chunkSize) { (foldInt, linkConsideration) =>
-                       val actualLinkClass = linkConsideration.linkClass
-                       val availableSeats = linkConsideration.link.availableSeats(actualLinkClass)
-                       if (availableSeats < foldInt) { availableSeats } else { foldInt }
-                     }
-                     //some capacity available on all the links, consume them NOMNOM NOM!
-                     if (consumptionSize > 0) {
-                       pickedRoute.links.foreach { linkConsideration =>
+                     synchronized {
+                       val consumptionSize = pickedRoute.links.foldLeft(chunkSize) { (foldInt, linkConsideration) =>
                          val actualLinkClass = linkConsideration.linkClass
-                         //val newAvailableSeats = linkConsideration.link.availableSeats(actualLinkClass) - consumptionSize
-
-                         linkConsideration.link.addSoldSeatsByClass(actualLinkClass, consumptionSize)
-                         //linkConsideration.link.availableSeats = LinkClassValues(linkConsideration.link.availableSeats.map.+(actualLinkClass -> newAvailableSeats))
-                         //                   if (link.availableSeats == 0) {
-                         //                     println("EXHAUSED!! = " + link)
-                         //                   }
+                         val availableSeats = linkConsideration.link.availableSeats(actualLinkClass)
+                         if (availableSeats < foldInt) {
+                           availableSeats
+                         } else {
+                           foldInt
+                         }
                        }
-                       consumptionResult.append((passengerGroup, toAirport, consumptionSize, pickedRoute))
-                     }
-                     //update the remaining demand chunk list
-                     if (consumptionSize < chunkSize) { //not totally satisfied
-                       //put a updated demand chunk
-                       remainingDemandChunks.append((passengerGroup, toAirport, chunkSize - consumptionSize));
+                       //some capacity available on all the links, consume them NOMNOM NOM!
+                       if (consumptionSize > 0) {
+                         pickedRoute.links.foreach { linkConsideration =>
+                           val actualLinkClass = linkConsideration.linkClass
+                           //val newAvailableSeats = linkConsideration.link.availableSeats(actualLinkClass) - consumptionSize
+
+                           linkConsideration.link.addSoldSeatsByClass(actualLinkClass, consumptionSize)
+                           //linkConsideration.link.availableSeats = LinkClassValues(linkConsideration.link.availableSeats.map.+(actualLinkClass -> newAvailableSeats))
+                           //                   if (link.availableSeats == 0) {
+                           //                     println("EXHAUSED!! = " + link)
+                           //                   }
+                         }
+
+                         consumptionResult.add((passengerGroup, toAirport, consumptionSize, pickedRoute))
+                       }
+                       //update the remaining demand chunk list
+                       if (consumptionSize < chunkSize) { //not totally satisfied
+                         //put a updated demand chunk
+                         remainingDemandChunks.add((passengerGroup, toAirport, chunkSize - consumptionSize));
+                       }
                      }
                    case Some(rejection) =>
                     import RouteRejectionReason._
                     rejection match {
                       case TOTAL_COST => // do not retry
-                        missedDemandChunks.append((passengerGroup, toAirport, chunkSize));
+                        missedDemandChunks.add((passengerGroup, toAirport, chunkSize));
                       case DISTANCE => //try again to see if there's any route within reasonable route distance
-                        remainingDemandChunks.append((passengerGroup, toAirport, chunkSize));
+                        remainingDemandChunks.add((passengerGroup, toAirport, chunkSize));
                       case LINK_COST =>//try again to see if there's any route with better links
-                        remainingDemandChunks.append((passengerGroup, toAirport, chunkSize));
+                        remainingDemandChunks.add((passengerGroup, toAirport, chunkSize));
                     }
                  }
                case None => //no route
-                 missedDemandChunks.append((passengerGroup, toAirport, chunkSize));
+                 missedDemandChunks.add((passengerGroup, toAirport, chunkSize));
+             }
+//           }
+           if (hasComputedRouteMap) {
+             if (progressChunk == 0 || counter.incrementAndGet() % progressChunk == 0) {
+               print(".")
+               if (progressCount.incrementAndGet() % 10 == 0) {
+                 print(progressCount.get + "% ")
+               }
              }
            }
         }
        println("Done!")
 
        //now process the remainingDemandChunks in next cycle
-       demandChunks = remainingDemandChunks.toList
+       demandChunks =  Random.shuffle(remainingDemandChunks.asScala.toList)
        consumptionCycleCount += 1
      }
 
     println("Total chunks that consume something " + consumptionResult.size)
     println("Total missed chunks " + missedDemandChunks.size)
 
-    println("Total transported pax " + consumptionResult.map(_._3).sum)
-    println("Total missed pax " + missedDemandChunks.map(_._3).sum)
+    println("Total transported pax " + consumptionResult.asScala.map(_._3).sum)
+    println("Total missed pax " + missedDemandChunks.asScala.map(_._3).sum)
 
     //collapse it now
-    val collapsedMap = consumptionResult.groupBy {
+    val collapsedMap = consumptionResult.asScala.groupBy {
       case(passengerGroup, toAirport, passengerCount, route) => (passengerGroup, toAirport, route)
     }.mapValues { consumptions => consumptions.map(_._3).sum }
 
     println("Collapsed consumption map size: " + collapsedMap.size)
 
 
-    val missedMap = missedDemandChunks.groupBy {
+    val missedMap = missedDemandChunks.asScala.groupBy {
       case(passengerGroup, toAirport, passengerCount) => (passengerGroup, toAirport)
     }.view.mapValues( missedChunks => missedChunks.map(_._3).sum).toMap
 
@@ -437,75 +464,46 @@ object PassengerSimulation {
                     establishedAllianceIdByAirlineId : java.util.Map[Int, Int] = Collections.emptyMap[Int, Int](),
                     externalCostModifier : Option[CostModifier] = None,
                     iterationCount : Int = 4) : Map[PassengerGroup, Map[Airport, Route]] = {
-    val totalRequiredRoutes = requiredRoutes.foldLeft(0){ case (currentCount, (fromAirport, toAirports)) => currentCount + toAirports.size }
-
-    println("Total routes to compute : " + totalRequiredRoutes)
-    println("Total passenger groups : " + requiredRoutes.size)
-    println(s"Iteration count : $iterationCount")
-
-    //val links = linksList.toArray
-
-    val counter = new AtomicInteger(0)
-    val progressCount = new AtomicInteger(0)
-    val progressChunk = requiredRoutes.size / 100
-
-
-
-//    val traceTimestampMap = new ConcurrentHashMap[Long, Long]()
-//    val maxTraceDuration = 60 * 1000; //1 min
-//    println("Agent ready? : " + AgentChecker.waitUntilAgentReady(10, TimeUnit.SECONDS))
-    val routeMaps : Map[PassengerGroup, Map[Airport, Route]] = requiredRoutes.toList.par.map {
-      case((passengerGroup : PassengerGroup, toAirports)) => {
-//        val currentThreadId = Thread.currentThread().getId
-//        val currentTime = System.currentTimeMillis()
-//        if (!traceTimestampMap.containsKey(currentThreadId) || (currentTime - traceTimestampMap.get(currentThreadId)) > maxTraceDuration) {
-//          if (TraceContext.isSampled(Trace.getCurrentXTraceID)) {
-//            println("ending " + currentThreadId)
-//            Trace.endTrace("thread-" + currentThreadId)
-//          }
-//          Trace.startTrace("thread-" + currentThreadId).report()
-//          println("tracing " + currentThreadId + " : " + Trace.getCurrentXTraceID)
-//          traceTimestampMap.put(currentThreadId, currentTime)
-//        }
-
-        val preferredLinkClass = passengerGroup.preference.preferredLinkClass
-        //remove links that's unknown to this airport then compute cost for each link. Cost is adjusted by the PassengerGroup's preference
-        val linkConsiderations = new ArrayList[LinkConsideration]()
-
-        linksList.foreach { link =>
-
-          //see if there are any seats for that class (or lower) left
-          link.availableSeatsAtOrBelowClass(preferredLinkClass).foreach {
-            case(matchingLinkClass, seatsLeft) =>
-              //2 instance of the link, one for each direction. Take note that the underlying link is the same, hence capacity and other params is shared properly!
-              val costProvider = CostStoreProvider() //use same instance of costProvider so this is only computed once
-              val linkConsideration1 = LinkConsideration(link, matchingLinkClass, false, passengerGroup, externalCostModifier, costProvider)
-              val linkConsideration2 = LinkConsideration(link, matchingLinkClass, true, passengerGroup, externalCostModifier, costProvider)
-              if (hasFreedom(linkConsideration1, passengerGroup.fromAirport, countryOpenness)) {
-                linkConsiderations.add(linkConsideration1)
-              }
-              if (hasFreedom(linkConsideration2, passengerGroup.fromAirport, countryOpenness)) {
-                linkConsiderations.add(linkConsideration2)
-              }
-          }
-        }
-
-        //then find the shortest route based on the cost
-
-        val routeMap : Map[Airport, Route] = findShortestRoute(passengerGroup, toAirports, activeAirportIds, linkConsiderations, establishedAllianceIdByAirlineId, iterationCount)
-        if (progressChunk == 0 || counter.incrementAndGet() % progressChunk == 0) {
-          print(".")
-          if (progressCount.incrementAndGet() % 10 == 0) {
-            print(progressCount.get + "% ")
-          }
-        }
-        //if (!routeMap.isEmpty) { println(routeMap) }
-        (passengerGroup, routeMap)
-      }
-    }.toMap.seq
-    
-    routeMaps  
+    requiredRoutes.map {
+      case (group, toAirports) => (group, findRoutesByPassengerGroup(group, toAirports,linksList, activeAirportIds, countryOpenness, establishedAllianceIdByAirlineId, externalCostModifier, iterationCount))
+    }
   }
+
+
+  def findRoutesByPassengerGroup(passengerGroup: PassengerGroup,
+                                  toAirports : Set[Airport],
+                    linksList : List[Transport],
+                    activeAirportIds : Set[Int],
+                    countryOpenness : Map[String, Int] = PassengerSimulation.countryOpenness,
+                    establishedAllianceIdByAirlineId : java.util.Map[Int, Int] = Collections.emptyMap[Int, Int](),
+                    externalCostModifier : Option[CostModifier] = None,
+                    iterationCount : Int = 4) : Map[Airport, Route] = {
+
+    val preferredLinkClass = passengerGroup.preference.preferredLinkClass
+    //remove links that's unknown to this airport then compute cost for each link. Cost is adjusted by the PassengerGroup's preference
+    val linkConsiderations = new ArrayList[LinkConsideration]()
+
+    linksList.foreach { link =>
+
+      //see if there are any seats for that class (or lower) left
+      link.availableSeatsAtOrBelowClass(preferredLinkClass).foreach {
+        case (matchingLinkClass, seatsLeft) =>
+          //2 instance of the link, one for each direction. Take note that the underlying link is the same, hence capacity and other params is shared properly!
+          val costProvider = CostStoreProvider() //use same instance of costProvider so this is only computed once
+          val linkConsideration1 = LinkConsideration(link, matchingLinkClass, false, passengerGroup, externalCostModifier, costProvider)
+          val linkConsideration2 = LinkConsideration(link, matchingLinkClass, true, passengerGroup, externalCostModifier, costProvider)
+          if (hasFreedom(linkConsideration1, passengerGroup.fromAirport, countryOpenness)) {
+            linkConsiderations.add(linkConsideration1)
+          }
+          if (hasFreedom(linkConsideration2, passengerGroup.fromAirport, countryOpenness)) {
+            linkConsiderations.add(linkConsideration2)
+          }
+      }
+    }
+    //val links = linksList.toArray
+    findShortestRoute(passengerGroup, toAirports, activeAirportIds, linkConsiderations, establishedAllianceIdByAirlineId, iterationCount)
+  }
+
   
   
   

--- a/airline-data/src/main/scala/com/patson/model/Link.scala
+++ b/airline-data/src/main/scala/com/patson/model/Link.scala
@@ -106,7 +106,7 @@ case class Link(from : Airport, to : Airport, airline: Airline, price : LinkClas
     getOfficeStaffRequired(from, to, frequency, capacity)
   }
 
-  val loadedFrequencyByClass = HashMap[LinkClass, Int]()
+  var loadedFrequencyByClass : LinkClassValues = LinkClassValues.getInstance()
   var frequencyByClassLoaded = false
 
   /**
@@ -115,8 +115,8 @@ case class Link(from : Airport, to : Airport, airline: Airline, price : LinkClas
   private def recomputeCapacityAndFrequency() = {
     var newCapacity = LinkClassValues.getInstance()
     var newFrequency = 0
+    val newFrequencyByClass = HashMap[LinkClass, Int]()
 
-    LinkClass.values.foreach(loadedFrequencyByClass.put(_, 0))
     inServiceAirplanes.foreach {
       case(airplane, assignment) =>
         newCapacity = newCapacity + (LinkClassValues(airplane.configuration.economyVal, airplane.configuration.businessVal, airplane.configuration.firstVal) * assignment.frequency)
@@ -124,13 +124,14 @@ case class Link(from : Airport, to : Airport, airline: Airline, price : LinkClas
 
         LinkClass.values.foreach { linkClass =>
           if (airplane.configuration(linkClass) > 0) {
-            loadedFrequencyByClass.put(linkClass, loadedFrequencyByClass(linkClass) + assignment.frequency)
+            newFrequencyByClass.put(linkClass, newFrequencyByClass.getOrElse(linkClass, 0) + assignment.frequency)
           }
         }
     }
-    frequencyByClassLoaded = true
     capacity = newCapacity
     frequency = newFrequency
+    loadedFrequencyByClass = LinkClassValues.getInstanceByMap(newFrequencyByClass.toMap)
+    frequencyByClassLoaded = true
   }
 
   def futureCapacity() = {


### PR DESCRIPTION
## Description
Very low price link between big destinations (for example JFK <-> LAX) could affect the demand of other competitors flying exactly the same link.

## Cause
The old algorithm first figure out all the route maps and then do the pax consumption. For link with very low price  Airport A <-> B, a lot of routes might include such link in the map, but the link will exhaust very early in the consumption iteration and the rest of demand will not able to use the route in that run.

And in the next run, a lot of flights flying into/out of A and B could be exhausted hence pax might not be able to find valid route going in and out of A and B even tho there are still capacity for other links going A <-> B

## Solution
Instead of first compute all route maps and then do consumption, we will do compute and then consumption right the way, the links will update dynamically hence exhausted link will be taken out of the route map computation. 

This is still not perfect as we still only compute route map on for each pax group on first encounter, which means it could still hold routes of later exhausted link (as we do not recompute until next run), but this should solve the low price low capacity issue as those links should be exhausted very quickly.