### PR TITLE
Add modern theme + save selected map mode

### DIFF
--- a/airline-web/app/views/index.scala.html
+++ b/airline-web/app/views/index.scala.html
@@ -31,6 +31,7 @@
 	  <link rel="stylesheet" type="text/css" href='@routes.Assets.versioned("javascripts/emojify/emojify.min.css")'>
 	  <link rel="stylesheet" type="text/css" href='@routes.Assets.versioned("javascripts/splitting/splitting.css")'>
 	  <link rel="stylesheet" type="text/css" href='@routes.Assets.versioned("javascripts/splitting/splitting-cells.css")'>
+	  <link rel="stylesheet" type="text/css" href='/assets/stylesheets/classic.css' id="cssTheme">
 	  <link rel="stylesheet" type="text/css" href='@routes.Assets.versioned("stylesheets/mobile.css")'> <!-- this has to be last so it overrides the CSS if mobile-->
 
 
@@ -101,6 +102,7 @@
 	<script src='@routes.Assets.versioned("javascripts/pending-action.js")'></script>
     <script src='@routes.Assets.versioned("javascripts/map-style.js")'></script>
 	<script src='@routes.Assets.versioned("javascripts/color-scheme.js")'></script>
+	<script src='@routes.Assets.versioned("javascripts/ui-theme.js")'></script>
 	<script src='@routes.Assets.versioned("javascripts/color.js")'></script>
 	<script src='@routes.Assets.versioned("javascripts/mobile.js")' defer></script>
     <script>
@@ -5334,6 +5336,17 @@
 							  <span class="switch-selection"></span>
 						  </div>
 					  </fieldset>
+				  </div>
+			  </div>
+			  <div class="table-row">
+				  <div class="cell">
+					  <h5>UI Theme</h5>
+				  </div>
+				  <div class="cell" style="vertical-align:middle; text-align:center;">
+					<select class="select-css" id="UIThemeSelecct" onchange="changeUITheme($(this).val());" style="margin: auto;">
+					  <option value="classic">Classic</option>
+					  <option value="modern">Modern</option>
+					</select>
 				  </div>
 			  </div>
 			  <div class="table-row">

--- a/airline-web/app/views/index.scala.html
+++ b/airline-web/app/views/index.scala.html
@@ -5346,6 +5346,7 @@
 					<select class="select-css" id="UIThemeSelecct" onchange="changeUITheme($(this).val());" style="margin: auto;">
 					  <option value="classic">Classic</option>
 					  <option value="modern">Modern</option>
+					  <option value="modern-lite">Modern Lite (For slow systems)</option>
 					</select>
 				  </div>
 			  </div>

--- a/airline-web/public/javascripts/delegate.js
+++ b/airline-web/public/javascripts/delegate.js
@@ -156,6 +156,10 @@ function refreshTopBarDelegates(airline) {
 }
 
 function showDelegateStatusModal() {
-    updateAirlineDelegateStatus($('#delegateStatusModal .delegateStatus'))
-    $('#delegateStatusModal').fadeIn(500)
+    if (!$("#delegateStatusModal").is(":visible")) {
+        updateAirlineDelegateStatus($('#delegateStatusModal .delegateStatus'))
+        $('#delegateStatusModal').fadeIn(500)
+    } else {
+        closeModal($('#delegateStatusModal'))
+    }
 }

--- a/airline-web/public/javascripts/main.js
+++ b/airline-web/public/javascripts/main.js
@@ -289,6 +289,7 @@ function initMap() {
    	minZoom : 2,
    	gestureHandling: 'greedy',
    	styles: getMapStyles(),
+	mapTypeId: getMapTypes(),
    	restriction: {
                 latLngBounds: { north: 85, south: -85, west: -180, east: 180 },
               }
@@ -300,6 +301,11 @@ function initMap() {
 	    $.each(markers, function( key, marker ) {
 	        marker.setVisible(isShowMarker(marker, zoom));
 	    })
+  });
+  
+  google.maps.event.addListener(map, 'maptypeid_changed', function() { 
+		var mapType = map.getMapTypeId();
+		$.cookie('currentMapTypes', mapType);
   });
 
   addCustomMapControls(map)

--- a/airline-web/public/javascripts/map-style.js
+++ b/airline-web/public/javascripts/map-style.js
@@ -1,4 +1,5 @@
 var currentStyles
+var currentTypes
 var pathOpacityByStyle = {
     "dark" : {
         highlight : "0.8",
@@ -19,6 +20,15 @@ function initStyles() {
 		$.cookie('currentMapStyles', currentStyles);
 	}
 	console.log("onload " + currentStyles)
+
+	console.log("onload cookie" + $.cookie('currentMapTypes'))
+	if ($.cookie('currentMapTypes')) {
+		currentTypes = $.cookie('currentMapTypes')
+	} else {
+		currentTypes = 'roadmap'
+		$.cookie('currentMapTypes', currentTypes);
+	}
+	console.log("onload " + currentTypes)
 }
 
 function getMapStyles() {
@@ -28,6 +38,11 @@ function getMapStyles() {
 	} else {
 		return darkStyles
 	}
+}
+
+function getMapTypes() {
+	console.log("getting " + currentTypes)
+	return currentTypes
 }
 
 function toggleMapLight() {

--- a/airline-web/public/javascripts/settings.js
+++ b/airline-web/public/javascripts/settings.js
@@ -1,7 +1,11 @@
 //determines if the user has a set theme
-function showSettings(){
-    updateCustomWallpaperPanel()
-    $("#settingsModal").fadeIn(500)
+function showSettings() {
+    if (!$("#settingsModal").is(":visible")){
+        updateCustomWallpaperPanel()
+        $("#settingsModal").fadeIn(500)
+    } else {
+        closeModal($('#settingsModal'))
+    }
 }
 
 
@@ -57,7 +61,11 @@ function refreshWallpaper() {
         } else { //somehow an index that does not exist, might happen when wallpaper list switches
             template = wallpaperTemplates[0]
         }
-
+        if (wallpaperIndex < 4) {
+            $("body").css("image-rendering", "pixelated")
+        } else {
+            $("body").css("image-rendering", "auto")
+        }
     }
 
 
@@ -65,6 +73,7 @@ function refreshWallpaper() {
     $("body").css("background-repeat", "no-repeat")
     $("body").css("background-attachment", "fixed")
     $("body").css("background-size", "cover")
+    $("body > div").css("image-rendering", "auto") // this prevents the non-pixel images from looking weird
 
 }
 

--- a/airline-web/public/javascripts/ui-theme.js
+++ b/airline-web/public/javascripts/ui-theme.js
@@ -17,3 +17,8 @@ function loadTheme() {
 }
 
 loadTheme();
+
+$( document ).ready(function() {
+    // preset the theme option in the dropdown
+    $("option[value=\"" + localStorage.getItem("UITheme") + "\"]").attr("selected", "selected")
+})

--- a/airline-web/public/javascripts/ui-theme.js
+++ b/airline-web/public/javascripts/ui-theme.js
@@ -1,4 +1,4 @@
-var themeList = ["classic", "modern"]
+var themeList = ["classic", "modern", "modern-lite"]
 
 function changeUITheme(theme){
 	if (!themeList.includes(theme)) {

--- a/airline-web/public/javascripts/ui-theme.js
+++ b/airline-web/public/javascripts/ui-theme.js
@@ -1,0 +1,19 @@
+var themeList = ["classic", "modern"]
+
+function changeUITheme(theme){
+	if (!themeList.includes(theme)) {
+		return;
+	}	
+
+	localStorage.setItem("UITheme", theme)
+	$("#cssTheme").attr("href", "/assets/stylesheets/" + theme + ".css") // this currently only allows one stylesheet per theme
+}
+
+function loadTheme() {
+	if (!localStorage.getItem("UITheme")) {
+		localStorage.setItem("UITheme", "classic")
+	}
+	changeUITheme(localStorage.getItem("UITheme"))
+}
+
+loadTheme();

--- a/airline-web/public/stylesheets/classic.css
+++ b/airline-web/public/stylesheets/classic.css
@@ -1,0 +1,1 @@
+/* Did you seriously expect something to be here???? */

--- a/airline-web/public/stylesheets/modern-lite.css
+++ b/airline-web/public/stylesheets/modern-lite.css
@@ -14,7 +14,9 @@ html {
     --input-background: #aaa;
     
     --color-1: #111;
-    
+	
+	--placeholderBlurColorLight: #fff;
+	--placeholderBlurColorDark: #202020;
 }
 html[data-theme="dark"] {
     --modal-background-color: #0003;

--- a/airline-web/public/stylesheets/modern-lite.css
+++ b/airline-web/public/stylesheets/modern-lite.css
@@ -1,53 +1,56 @@
 html {
-	--shadow-1: 0px 5px 5px 0px rgba(0, 0, 0, 0.3);
-	--shadow-2: 0px 5px 5px 0px rgba(0, 0, 0, 0.5);
-	
-	--backdrop-blur: blur(48px) saturate(1.25);
-	
-	--modal-background-color: #0003;
-	--section-background-image: linear-gradient(#fffa, #fffa);
-	--modal-content-background-image: linear-gradient(#fffa, #fffa);
-	
-	--background-1: #fffa;
-	--background-2: #ccc5;
-	--background-3: #fffc;
-	--input-background: #aaa3;
-	
-	--color-1: #111;
-	
-	--placeholderBlurColorLight: #c0c5d0;
-	--placeholderBlurColorDark: #111518;
+    --shadow-1: 0px 5px 5px 0px rgba(0, 0, 0, 0.3);
+    --shadow-2: 0px 5px 5px 0px rgba(0, 0, 0, 0.5);
+    
+    --backdrop-blur: none;
+    
+    --modal-background-color: #0003;
+    --section-background-image: linear-gradient(#fff, #fff);
+    --modal-content-background-image: linear-gradient(#fff, #fff);
+    
+    --background-1: #fff;
+    --background-2: #ccc;
+    --background-3: #eee;
+    --input-background: #aaa;
+    
+    --color-1: #111;
+    
 }
 html[data-theme="dark"] {
-	--modal-background-color: #0003;
-	--section-background-image: linear-gradient(#111a, #111a);
-	--modal-content-background-image: linear-gradient(#111a, #111a);
-	
-	--background-1: #111a;
-	--background-2: #1115;
-	--background-3: #202020aa;
-	--input-background: #aaa3;
-	
-	--color-1: #ccc;
-	
+    --modal-background-color: #0003;
+    --section-background-image: linear-gradient(#202020, #202020);
+    --modal-content-background-image: linear-gradient(#202020, #202020);
+    
+    --background-1: #202020;
+    --background-2: #2a2a2a;
+    --background-3: #333;
+    --input-background: #aaa3;
+    
+    --color-1: #ccc;
+    
 }
 
 /* fonts */
 @font-face {
-	font-family: "Open Sans";
-	src: local("Segoe UI")
+    font-family: "Open Sans";
+    src: local("Segoe UI"), local("Tahoma")
 }
 @font-face {
-	font-family: "Verdana";
-	src: local("Segoe UI Variable"), local("Segoe UI")
+    font-family: "Verdana";
+    src: local("Segoe UI Variable"), local("Segoe UI"), local("Verdana")
 }
 @font-face {
-	font-family: "Arial";
-	src: local("Segoe UI Variable"), local("Segoe UI")
+    font-family: "Arial";
+    src: local("Segoe UI Variable"), local("Segoe UI"), local("Arial")
 }
 	
 .section, div.modal-content, div.tab-icon, #live-chat header, .chat, input, .gm-style .gm-style-iw-c, #topBar > div, #map .gmnoprint[role="menubar"], .gm-fullscreen-control, .googleMapIcon, .gm-svpc, .gm-control-active, div[style="position: relative; overflow: hidden; width: 30px; height: 1px; margin: 0px 5px; background-color: rgb(230, 230, 230); top: 0px;"], div[style="user-select: none; box-shadow: rgba(0, 0, 0, 0.3) 0px 1px 4px -1px; border-radius: 2px; cursor: pointer; background-color: rgb(255, 255, 255); width: 40px; height: 81px;"], .extendedTopBarDetails, .customTooltip .tooltiptext, #moreTopBarTab li {
 	backdrop-filter: var(--backdrop-blur) !important;
+}
+
+.tooltiptext, .label {
+    background-color: var(--background-1) !important;
+    color: var(--color-1) !important
 }
 div.section {
 	border-radius: 8px;
@@ -354,6 +357,9 @@ html[data-theme="dark"] :is(.gm-fullscreen-control img, .gmnoprint div button im
 	left: 50px !important;
 	box-shadow: var(--shadow-2) !important;
 	border-radius: 8px !important
+}
+div[style="position: relative; overflow: hidden; width: 30px; height: 1px; margin: 0px 5px; background-color: rgb(230, 230, 230); top: 0px;"] {
+    opacity: 0
 }
 /* Mobile */
 .extendedTopBarDetails {

--- a/airline-web/public/stylesheets/modern.css
+++ b/airline-web/public/stylesheets/modern.css
@@ -46,7 +46,7 @@ html[data-theme="dark"] {
 	src: local("Segoe UI Variable"), local("Segoe UI")
 }
 	
-.section, div.modal-content, div.tab-icon, #live-chat header, .chat, input, .gm-style .gm-style-iw-c, #topBar > div, #map .gmnoprint[role="menubar"], .gm-fullscreen-control, .googleMapIcon, .gm-svpc, .gm-control-active, div[style="position: relative; overflow: hidden; width: 30px; height: 1px; margin: 0px 5px; background-color: rgb(230, 230, 230); top: 0px;"], div[style="user-select: none; box-shadow: rgba(0, 0, 0, 0.3) 0px 1px 4px -1px; border-radius: 2px; cursor: pointer; background-color: rgb(255, 255, 255); width: 40px; height: 81px;"], .extendedTopBarDetails, .customTooltip .tooltiptext {
+.section, div.modal-content, div.tab-icon, #live-chat header, .chat, input, .gm-style .gm-style-iw-c, #topBar > div, #map .gmnoprint[role="menubar"], .gm-fullscreen-control, .googleMapIcon, .gm-svpc, .gm-control-active, div[style="position: relative; overflow: hidden; width: 30px; height: 1px; margin: 0px 5px; background-color: rgb(230, 230, 230); top: 0px;"], div[style="user-select: none; box-shadow: rgba(0, 0, 0, 0.3) 0px 1px 4px -1px; border-radius: 2px; cursor: pointer; background-color: rgb(255, 255, 255); width: 40px; height: 81px;"], .extendedTopBarDetails, .customTooltip .tooltiptext, #moreTopBarTab li {
 	backdrop-filter: var(--backdrop-blur) !important;
 }
 div.section {
@@ -131,7 +131,7 @@ div#topBar {
 	backdrop-filter: none !important;
 }
 #live-chat {
-	left: 50px;
+	left: 50px !important;
 	box-shadow: var(--shadow-1);
 }
 /* disable screen dimming on some modals */
@@ -241,7 +241,15 @@ html[data-theme="dark"] :is(.gm-fullscreen-control img, .gmnoprint div button im
 	opacity: 1 !important
 }
 .tab-icon {
-	transition: all 0.1s
+    transition: all 0.1s;
+    background: var(--background-1) !important;
+    box-shadow: var(--shadow-1) !important
+}
+.tab-icon:is(.selected, :hover) {
+    background: var(--background-2) !important;
+}
+.tab-icon:hover:active {
+    background: var(--background-3) !important;
 }
 .canvas {
 	padding-left: 40px
@@ -348,30 +356,42 @@ html[data-theme="dark"] :is(.gm-fullscreen-control img, .gmnoprint div button im
 	border-radius: 8px !important
 }
 /* Mobile */
+/* Mobile */
 .extendedTopBarDetails {
-	position: absolute;
-	z-index: 100000;
-	height: 40px;
+    position: absolute;
+    z-index: 100000;
+    height: 40px;
+    box-shadow: var(--shadow-1)
 }
 #topBar > .mobileOnly {
-	background-color: var(--background-1);
-	border-bottom-right-radius: 6px;
-	height: 40px;
+    background-color: var(--background-1);
+    border-bottom-right-radius: 6px;
+    height: 40px;
+}
+#moreTopBarTab li {
+    border: none !important;
+    box-shadow: var(--shadow-1) !important;
+}
+#map {
+	height: 100% !important;
 }
 @media screen and (max-width: 640px) {
-	#topBar {
-		height: 40px
-	}
-	#topBar > :last-child {
-		top: 0px;
-		right: 0px;
-		border-radius: 0 0 0 6px;
-		padding-block: 5px
-	}
-	#sidePanel {
-		width: calc(100vw - 73px);
-		margin-top: 50vh
-	}
+    #topBar {
+        height: 40px
+    }
+    #topBar > :last-child {
+        top: 0px;
+        right: 0px;
+        border-radius: 0 0 0 6px;
+        padding-block: 5px
+    }
+    #sidePanel {
+        width: calc(100vw - 73px);
+        margin-top: 50vh
+    }
+    #live-chat {
+        left: 0% !important;
+    }
 }
 /* Always show map, kinda broken *
 #worldMapCanvas {
@@ -387,4 +407,30 @@ html[data-theme="dark"] :is(.gm-fullscreen-control img, .gmnoprint div button im
 select option {
 	background: var(--background-1);
 	color: var(--color-1)
+}
+/* chat */
+.chat-history ul > :last-child {
+    border-radius: 0 0 6px 6px;
+    box-shadow: var(--shadow-1);
+}
+.chat-history ul > :first-child {
+    border-radius: 6px 6px 0 0
+}
+.chat-history {
+    font-family: Segoe UI, Helvetica, serif
+}
+.ctabs > li {
+    box-shadow: var(--shadow-1) !important;
+    border: none !important;
+    background: var(--background-2) !important
+}
+.ctabs > li.current {
+    background: var(--background-1) !important
+}
+#live-chat header {
+    border: none
+}
+#chat-box {
+    background: var(--background-1);
+    padding-top: 8px;
 }

--- a/airline-web/public/stylesheets/modern.css
+++ b/airline-web/public/stylesheets/modern.css
@@ -1,0 +1,378 @@
+html {
+	--shadow-1: 0px 5px 5px 0px rgba(0, 0, 0, 0.3);
+	--shadow-2: 0px 5px 5px 0px rgba(0, 0, 0, 0.5);
+	
+	--backdrop-blur: blur(48px) saturate(1.25);
+	
+	--modal-background-color: #0003;
+	--section-background-image: linear-gradient(#fffa, #fffa);
+	--modal-content-background-image: linear-gradient(#fffa, #fffa);
+	
+	--background-1: #fffa;
+	--background-2: #ccc5;
+	--background-3: #fffc;
+	--input-background: #aaa3;
+	
+	--color-1: #111;
+	
+	--placeholderBlurColorLight: #c0c5d0;
+	--placeholderBlurColorDark: #111518;
+}
+html[data-theme="dark"] {
+	--modal-background-color: #0003;
+	--section-background-image: linear-gradient(#111a, #111a);
+	--modal-content-background-image: linear-gradient(#111a, #111a);
+	
+	--background-1: #111a;
+	--background-2: #1115;
+	--background-3: #202020aa;
+	--input-background: #aaa3;
+	
+	--color-1: #ccc;
+	
+}
+
+/* fonts */
+@font-face {
+	font-family: "Open Sans";
+	src: local("Segoe UI")
+}
+@font-face {
+	font-family: "Verdana";
+	src: local("Segoe UI Variable"), local("Segoe UI")
+}
+@font-face {
+	font-family: "Arial";
+	src: local("Segoe UI Variable"), local("Segoe UI")
+}
+	
+.section, div.modal-content, div#topBar, div.tab-icon, #live-chat header, .chat, input, .gm-style .gm-style-iw-c, #topBar > div, #map .gmnoprint[role="menubar"], .gm-fullscreen-control, .googleMapIcon, .gm-svpc, .gm-control-active, div[style="position: relative; overflow: hidden; width: 30px; height: 1px; margin: 0px 5px; background-color: rgb(230, 230, 230); top: 0px;"], div[style="user-select: none; box-shadow: rgba(0, 0, 0, 0.3) 0px 1px 4px -1px; border-radius: 2px; cursor: pointer; background-color: rgb(255, 255, 255); width: 40px; height: 81px;"], .extendedTopBarDetails {
+	backdrop-filter: var(--backdrop-blur) !important;
+}
+div.section {
+	border-radius: 8px !important;
+}
+/* sections broken with backdrop-filter */
+/* broken tooltips */
+.airportCanvasLeftGroup > :first-child .section {
+	backdrop-filter: none !important;
+	background: var(--placeholderBlurColorLight)/* << This color should be taken from one of the sections that have backdrop-filter */
+}
+html[data-theme="dark"] .airportCanvasLeftGroup > :first-child .section {
+	background: var(--placeholderBlurColorDark)/* << This color should be taken from one of the sections that have backdrop-filter */
+}
+.tooltiptext:has(img[data-src="/assets/images/clips/flight-frequency.gif"]), .progressionItem .tooltiptext {
+	bottom: 125% !important;
+	top: unset !important
+}
+.tooltiptext[style="text-transform: none; top: 0px; width: 350px; white-space: nowrap;"] {
+	width: fit-content !important
+}
+/**/
+.tooltiptext::after {
+	display: none
+}
+div.section, #topBar > div {
+	box-shadow: var(--shadow-1);
+}
+div.button, .mapPopup div.button {
+	box-shadow: var(--shadow-1);
+	background-color: var(--background-1);
+	transition: all 0.2s;
+}
+div.button:hover:not([class*="disabled"]) {
+	background-color: var(--background-3);
+}
+div.button:active:not([class*="disabled"]) {
+	background-color: var(--background-1);
+}
+.gm-style-iw .gm-style-iw-d {
+	overflow: clip !important;
+}
+/**/
+#patreonDiv a img {
+	height: 25px;
+	border-radius: 2px
+}
+#topBar {
+	pointer-events: none;
+}
+#topBar * {
+	pointer-events: auto;
+}
+#topBar > :last-child {
+	background-color: var(--background-1);
+	position: absolute !important;
+	top: 3px;
+	right: 3px;
+	padding-left: 5px;
+	padding-right: 2px;
+	border-radius: 6px
+}
+#topBar > :first-child {
+	background-color: var(--background-1);
+	position: absolute !important;
+	top: 3px;
+	left: 3px;
+	padding-right: 10px;
+	padding-left: 3px;
+	border-radius: 6px;
+	padding-block: 10px;
+}
+div#topBar {
+	box-shadow: none;
+	/* background: #111a;*/
+	border: none;
+	position: fixed !important;
+	background: none;
+	backdrop-filter: none !important;
+}
+#live-chat {
+	left: 50px !important;
+	box-shadow: var(--shadow-1);
+}
+/* disable screen dimming on some modals */
+@media screen and (min-width: 640px) {
+	#delegateStatusModal, #settingsModal {
+		background: none;
+		pointer-events: none;
+	}
+	#delegateStatusModal .modal-content, #settingsModal .modal-content {
+		pointer-events: auto;
+		position: absolute;
+		margin: 0;
+		top: 48px;
+	}
+	#delegateStatusModal .modal-content {
+		left: 300px
+	}
+	#settingsModal .modal-content {
+		right: 100px
+	}
+}
+/**/
+/* back button for when you place the google maps man */
+div[jstcache="0"] > div:is([style="z-index: 24601; position: absolute; left: 0px; top: 0px;"], [style="position: absolute; left: 28px; top: 0px;"]) {
+	top: 50px !important;
+	left: 50px !important
+}
+#mainContainer {
+	padding-top: 40px;
+}
+.gm-style .gm-style-iw-c {
+	background: var(--background-1);
+}
+.mapPopup, .mapPopup > div > h4, .gm-style .gm-style-iw-c {
+	color: var(--color-1);
+}
+html[data-theme="dark"] [title="Close"] > span {
+	filter: invert(1) !important
+}
+.tooltip .tooltiptext {
+	box-shadow: var(--shadow-1);
+	backdrop-filter: var(--backdrop-blur) !important;
+}
+.modal-content, #live-chat header, div.tab-icon, #main-tabs .left-tab div.tab-icon, input, .select-css {
+	box-shadow: var(--shadow-1);
+}
+.table .cell.detailsSelection {
+	box-shadow: var(--shadow-1) !important;
+}
+.table-header .cell {
+	box-shadow: 0px 0px 5px 0px rgba(0, 0, 0, 0.4) inset !important;
+}
+#map .gmnoprint[role="menubar"] {
+	background: var(--background-1) !important;
+	border-radius: 8px;
+	box-shadow: var(--shadow-1) !important;
+}
+/* top-left map type selector */
+.gm-style-mtc > button, .gm-style-mtc {
+	background-color: #0000 !important;
+	color: var(--color-1) !important;
+	box-shadow: none !important;
+}
+/* arrow that's part of the airport box */
+.gm-style .gm-style-iw-tc::after {
+	display: none
+}
+.gm-fullscreen-control, .googleMapIcon, .gm-svpc, .gm-control-active {
+	background: var(--background-1) !important;
+}
+/* this was the only way to select these that i could find */
+/* zoom buttons */
+div[style="user-select: none; box-shadow: rgba(0, 0, 0, 0.3) 0px 1px 4px -1px; border-radius: 2px; cursor: pointer; background-color: rgb(255, 255, 255); width: 40px; height: 81px;"] {
+	background: var(--background-3) !important
+}
+div[style="position: relative; overflow: hidden; width: 30px; height: 1px; margin: 0px 5px; background-color: rgb(230, 230, 230); top: 0px;"] {
+	background: none !important
+}
+input, .select-css {
+	background: var(--input-background);
+	border: none !important
+}
+.planLinkPrice {
+	width: 64px
+}
+.gm-ui-hover-effect {
+	top: 0 !important;
+	right: 0 !important
+}
+.mapPopup * {
+	color: var(--color-1) !important
+}
+.left-tab .label {
+	box-shadow: var(--shadow-1);
+	backdrop-filter: var(--backdrop-blur) !important;
+}
+html[data-theme="dark"] :is(.gm-fullscreen-control img, .gmnoprint div button img) {
+	filter: invert(1)
+}
+/*==left icons, should be disabled in js or whatever==*/
+#tabGroup {
+	display: block !important;
+	opacity: 1 !important
+}
+.tab-icon {
+	transition: all 0.1s
+}
+.canvas {
+	padding-left: 40px
+}
+/*===== vv fullscreen map vv =====*/
+#map {
+	width: 100%;
+	height: 100%;
+	top: 0px !important;
+	position: fixed !important
+}
+#hideRivalMapButton {
+	top: 48px !important
+}
+#sidePanel {
+	position: absolute;
+	right: 32px;
+	width: 40%;
+	pointer-events: none;
+	border-radius: 8px !important;
+}
+#sidePanel > * {
+	pointer-events: auto;
+}
+#map .gmnoprint[role="menubar"] {
+	position: fixed !important;
+	top: 40px !important;
+	left: 40px !important;
+	width: 100px
+}
+#map .gmnoprint[role="menubar"] > :first-child {
+	border-radius: 8px 8px 0 0 !important;
+}
+#map .gmnoprint[role="menubar"] > :last-child {
+	border-radius: 0 0 8px 8px !important;
+}
+#map .gmnoprint[role="menubar"] > * {
+	transition: all 0.2s !important;
+	width: 100px;
+	height: 40px !important
+}
+#map .gmnoprint[role="menubar"] > * button {
+	width: 100px;
+	padding: 0px !important
+}
+#map .gmnoprint[role="menubar"] > *:hover {
+	background: var(--background-2) !important
+}
+#map .gmnoprint[role="menubar"] > *:hover:active {
+	background: var(--background-1) !important
+}
+#map .gmnoprint[role="menubar"] ul:has(.ssQIHO-checkbox-menu-item) {
+	position: relative !important;
+	border-radius: 4px !important;
+	filter: invert(.9);
+	box-shadow: 0 5px 5px 0 #fff4 !important
+}
+#map .gmnoprint[role="menubar"] ul:has(.ssQIHO-checkbox-menu-item) {
+	left: 100% !important;
+	top: -100% !important;
+}
+.gm-fullscreen-control {
+	position: fixed !important;
+	top: 40px !important;
+	border-radius: 8px !important;
+	box-shadow: var(--shadow-2) !important;
+}
+#map div[style="user-select: none; box-shadow: rgba(0, 0, 0, 0.3) 0px 1px 4px -1px; border-radius: 2px; cursor: pointer; background-color: rgb(255, 255, 255); width: 40px; height: 81px;"] {
+	position: fixed !important;
+	top: 96px !important;
+	border-radius: 8px !important;
+	box-shadow: var(--shadow-2) !important;
+}
+#map div[style="user-select: none; box-shadow: rgba(0, 0, 0, 0.3) 0px 1px 4px -1px; border-radius: 2px; cursor: pointer; background-color: rgb(255, 255, 255); width: 40px; height: 81px;"] > * {
+	border-radius: 6px !important;
+	max-height: 36px !important;
+	max-width: 36px !important;
+	margin-top: 2px !important;
+	margin-left: 2px !important
+}
+#map .googleMapIcon {
+	position: fixed !important;
+	border-radius: 8px;
+	box-shadow: var(--shadow-2) !important;
+}
+#map #toggleMapHeatmapButton {
+	top: 183px
+}
+#map #toggleChampionButton {
+	top: 229px
+}
+#map #toggleMapAnimationButton {
+	top: 275px
+}
+#map #toggleMapLightButton {
+	top: 321px
+}
+#map .gm-svpc {
+	position: fixed !important;
+	top: 136px !important;
+	left: 50px !important;
+	box-shadow: var(--shadow-2) !important;
+	border-radius: 8px !important
+}
+/* Mobile */
+.extendedTopBarDetails {
+	position: absolute;
+	z-index: 100000;
+	height: 40px;
+}
+#topBar > .mobileOnly {
+	background-color: var(--background-1);
+	border-bottom-right-radius: 6px;
+	height: 40px;
+}
+@media screen and (max-width: 640px) {
+	#topBar {
+		height: 40px
+	}
+	#topBar > :last-child {
+		top: 0px;
+		right: 0px;
+		border-radius: 0 0 0 6px;
+		padding-block: 5px
+	}
+	#sidePanel {
+		width: calc(100vw - 73px);
+		margin-top: 50vh
+	}
+}
+/* Always show map *
+#worldMapCanvas {
+	opacity: 1 !important
+}
+#worldMapCanvas.active {
+	position: unset !important;
+}
+#worldMapCanvas:not(.active) {
+	display: block !important;
+	position: fixed !important;
+}/**/

--- a/airline-web/public/stylesheets/modern.css
+++ b/airline-web/public/stylesheets/modern.css
@@ -34,16 +34,16 @@ html[data-theme="dark"] {
 
 /* fonts */
 @font-face {
-	font-family: "Open Sans";
-	src: local("Segoe UI")
+    font-family: "Open Sans";
+    src: local("Segoe UI"), local("Tahoma")
 }
 @font-face {
-	font-family: "Verdana";
-	src: local("Segoe UI Variable"), local("Segoe UI")
+    font-family: "Verdana";
+    src: local("Segoe UI Variable"), local("Segoe UI"), local("Verdana")
 }
 @font-face {
-	font-family: "Arial";
-	src: local("Segoe UI Variable"), local("Segoe UI")
+    font-family: "Arial";
+    src: local("Segoe UI Variable"), local("Segoe UI"), local("Arial")
 }
 	
 .section, div.modal-content, div.tab-icon, #live-chat header, .chat, input, .gm-style .gm-style-iw-c, #topBar > div, #map .gmnoprint[role="menubar"], .gm-fullscreen-control, .googleMapIcon, .gm-svpc, .gm-control-active, div[style="position: relative; overflow: hidden; width: 30px; height: 1px; margin: 0px 5px; background-color: rgb(230, 230, 230); top: 0px;"], div[style="user-select: none; box-shadow: rgba(0, 0, 0, 0.3) 0px 1px 4px -1px; border-radius: 2px; cursor: pointer; background-color: rgb(255, 255, 255); width: 40px; height: 81px;"], .extendedTopBarDetails, .customTooltip .tooltiptext, #moreTopBarTab li {

--- a/airline-web/public/stylesheets/modern.css
+++ b/airline-web/public/stylesheets/modern.css
@@ -46,11 +46,11 @@ html[data-theme="dark"] {
 	src: local("Segoe UI Variable"), local("Segoe UI")
 }
 	
-.section, div.modal-content, div#topBar, div.tab-icon, #live-chat header, .chat, input, .gm-style .gm-style-iw-c, #topBar > div, #map .gmnoprint[role="menubar"], .gm-fullscreen-control, .googleMapIcon, .gm-svpc, .gm-control-active, div[style="position: relative; overflow: hidden; width: 30px; height: 1px; margin: 0px 5px; background-color: rgb(230, 230, 230); top: 0px;"], div[style="user-select: none; box-shadow: rgba(0, 0, 0, 0.3) 0px 1px 4px -1px; border-radius: 2px; cursor: pointer; background-color: rgb(255, 255, 255); width: 40px; height: 81px;"], .extendedTopBarDetails {
+.section, div.modal-content, div.tab-icon, #live-chat header, .chat, input, .gm-style .gm-style-iw-c, #topBar > div, #map .gmnoprint[role="menubar"], .gm-fullscreen-control, .googleMapIcon, .gm-svpc, .gm-control-active, div[style="position: relative; overflow: hidden; width: 30px; height: 1px; margin: 0px 5px; background-color: rgb(230, 230, 230); top: 0px;"], div[style="user-select: none; box-shadow: rgba(0, 0, 0, 0.3) 0px 1px 4px -1px; border-radius: 2px; cursor: pointer; background-color: rgb(255, 255, 255); width: 40px; height: 81px;"], .extendedTopBarDetails, .customTooltip .tooltiptext {
 	backdrop-filter: var(--backdrop-blur) !important;
 }
 div.section {
-	border-radius: 8px !important;
+	border-radius: 8px;
 }
 /* sections broken with backdrop-filter */
 /* broken tooltips */
@@ -87,7 +87,10 @@ div.button:active:not([class*="disabled"]) {
 	background-color: var(--background-1);
 }
 .gm-style-iw .gm-style-iw-d {
-	overflow: clip !important;
+    overflow: clip !important;
+}
+.gm-style-iw[style*="padding-bottom: 0px"] {
+    padding-bottom: 12px !important
 }
 /**/
 #patreonDiv a img {
@@ -102,7 +105,7 @@ div.button:active:not([class*="disabled"]) {
 }
 #topBar > :last-child {
 	background-color: var(--background-1);
-	position: absolute !important;
+	position: absolute;
 	top: 3px;
 	right: 3px;
 	padding-left: 5px;
@@ -111,7 +114,7 @@ div.button:active:not([class*="disabled"]) {
 }
 #topBar > :first-child {
 	background-color: var(--background-1);
-	position: absolute !important;
+	position: absolute;
 	top: 3px;
 	left: 3px;
 	padding-right: 10px;
@@ -128,7 +131,7 @@ div#topBar {
 	backdrop-filter: none !important;
 }
 #live-chat {
-	left: 50px !important;
+	left: 50px;
 	box-shadow: var(--shadow-1);
 }
 /* disable screen dimming on some modals */
@@ -152,9 +155,13 @@ div#topBar {
 }
 /**/
 /* back button for when you place the google maps man */
-div[jstcache="0"] > div:is([style="z-index: 24601; position: absolute; left: 0px; top: 0px;"], [style="position: absolute; left: 28px; top: 0px;"]) {
+div[jstcache="0"] > div:is([style="z-index: 24601; position: absolute; left: 0px; top: 0px;"]) {
 	top: 50px !important;
 	left: 50px !important
+}
+div[jstcache="0"] > :has(> .gm-iv-address) {
+	top: 50px !important;
+	left: 78px !important;
 }
 #mainContainer {
 	padding-top: 40px;
@@ -166,7 +173,7 @@ div[jstcache="0"] > div:is([style="z-index: 24601; position: absolute; left: 0px
 	color: var(--color-1);
 }
 html[data-theme="dark"] [title="Close"] > span {
-	filter: invert(1) !important
+	filter: invert(1)
 }
 .tooltip .tooltiptext {
 	box-shadow: var(--shadow-1);
@@ -182,9 +189,9 @@ html[data-theme="dark"] [title="Close"] > span {
 	box-shadow: 0px 0px 5px 0px rgba(0, 0, 0, 0.4) inset !important;
 }
 #map .gmnoprint[role="menubar"] {
-	background: var(--background-1) !important;
+	background: var(--background-1);
 	border-radius: 8px;
-	box-shadow: var(--shadow-1) !important;
+	box-shadow: var(--shadow-1);
 }
 /* top-left map type selector */
 .gm-style-mtc > button, .gm-style-mtc {
@@ -228,7 +235,7 @@ input, .select-css {
 html[data-theme="dark"] :is(.gm-fullscreen-control img, .gmnoprint div button img) {
 	filter: invert(1)
 }
-/*==left icons, should be disabled in js or whatever==*/
+/*==left icons, should be disabled in js but i don't really like adding js to 'themes'==*/
 #tabGroup {
 	display: block !important;
 	opacity: 1 !important
@@ -365,7 +372,7 @@ html[data-theme="dark"] :is(.gm-fullscreen-control img, .gmnoprint div button im
 		margin-top: 50vh
 	}
 }
-/* Always show map *
+/* Always show map, kinda broken *
 #worldMapCanvas {
 	opacity: 1 !important
 }

--- a/airline-web/public/stylesheets/modern.css
+++ b/airline-web/public/stylesheets/modern.css
@@ -323,9 +323,10 @@ html[data-theme="dark"] :is(.gm-fullscreen-control img, .gmnoprint div button im
 	margin-left: 2px !important
 }
 #map .googleMapIcon {
-	position: fixed !important;
-	border-radius: 8px;
-	box-shadow: var(--shadow-2) !important;
+    position: fixed !important;
+    border-radius: 8px;
+    box-shadow: var(--shadow-2) !important;
+    left: 40px !important
 }
 #map #toggleMapHeatmapButton {
 	top: 183px

--- a/airline-web/public/stylesheets/modern.css
+++ b/airline-web/public/stylesheets/modern.css
@@ -383,3 +383,7 @@ html[data-theme="dark"] :is(.gm-fullscreen-control img, .gmnoprint div button im
 	display: block !important;
 	position: fixed !important;
 }/**/
+select option {
+	background: var(--background-1);
+	color: var(--color-1)
+}


### PR DESCRIPTION
This adds a modern theme, selectable in the settings menu, for the game. Currently the old (classic) theme is the default.
Also saves and remembers the user's map type and pixelates the pixel background.

Someone also recommended to make the `currentMapStyles` and the new `currentMapTypes` cookies last for more than a session. This PR currently doesn't affect their lifespan.