### PR TITLE
Added cycle number tooltip

### DIFF
--- a/airline-web/public/javascripts/main.js
+++ b/airline-web/public/javascripts/main.js
@@ -443,6 +443,7 @@ var days = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
 
 
 function updateTime(cycle, fraction, cycleDurationEstimation) {
+	$(".currentTime").attr("title", "Current Cycle: " + cycle)
 	currrentCycle = cycle
 	currentTime = (cycle + fraction) * totalmillisecPerWeek 
 	if (refreshIntervalTimer) {


### PR DESCRIPTION
As [Saputnik suggested over on Discord](https://discord.com/channels/830517521987534859/830524023757602886/1182550200406003712), this adds a tooltip showing the current cycle number, which is visible when hovering over the date (in the top menu bar on desktop). It works without needing any extra server requests, and is overall a simple change. 
![image](https://github.com/patsonluk/airline/assets/72092800/fbb61565-ac63-4d39-906d-d53b5bc9d891)
