### PR TITLE
Fixed delegate issue https://github.com/patsonluk/airline/issues/581

### DIFF
--- a/airline-data/src/main/scala/com/patson/DelegateSimulation.scala
+++ b/airline-data/src/main/scala/com/patson/DelegateSimulation.scala
@@ -6,16 +6,17 @@ object DelegateSimulation {
   def simulate(currentCycle : Int ) = {
     DelegateSource.deleteBusyDelegateByCriteria(List(("available_cycle", "<=", currentCycle)))
 
-    //update/refresh delegates
-    AirlineSource.loadAllAirlines().foreach { airline =>
-      val delegateInfo = airline.getDelegateInfo()
-      if (delegateInfo.availableCount < 0) {
-        println(s"Removing ${delegateInfo.availableCount} delegates from $airline")
-        val removingDelegates = delegateInfo.busyDelegates.sortBy(_.id).takeRight(delegateInfo.availableCount * -1) //take the newest ones away
-        DelegateSource.deleteBusyDelegates(removingDelegates)
-      }
-    }
 
+    // Commented out below as we should just let it go negative. Otherwise exploit to assign bonus delegates to country,
+    // build base then let delegates expired/removed but bases remain
+//    AirlineSource.loadAllAirlines().foreach { airline =>
+//      val delegateInfo = airline.getDelegateInfo()
+//      if (delegateInfo.availableCount < 0) {
+//        println(s"Removing ${delegateInfo.availableCount} delegates from $airline")
+//        val removingDelegates = delegateInfo.busyDelegates.sortBy(_.id).takeRight(delegateInfo.availableCount * -1) //take the newest ones away
+//        DelegateSource.deleteBusyDelegates(removingDelegates)
+//      }
+//    }
   }
 
 }

--- a/airline-data/src/main/scala/com/patson/patch/Issue581DelegatePatcher.scala
+++ b/airline-data/src/main/scala/com/patson/patch/Issue581DelegatePatcher.scala
@@ -1,0 +1,39 @@
+package com.patson.patch
+
+import com.mchange.v2.c3p0.ComboPooledDataSource
+import com.patson.data.{AirlineSource, CycleSource, DelegateSource}
+import com.patson.data.Constants._
+import com.patson.init.GenericTransitGenerator
+import com.patson.model.{BusyDelegate, CountryDelegateTask, DelegateTask, DelegateTaskType}
+import com.patson.util.CountryCache
+
+import scala.collection.mutable.ListBuffer
+
+
+object Issue581DelegatePatcher extends App {
+  mainFlow
+
+
+  def mainFlow() {
+    val currentCycle = CycleSource.loadCycle()
+    AirlineSource.loadAllAirlines(fullLoad = true).foreach { airline =>
+      val delegateTaskCountry = airline.getDelegateInfo().busyDelegates.filter(_.assignedTask.getTaskType == DelegateTaskType.COUNTRY).map(_.assignedTask.asInstanceOf[CountryDelegateTask].country.countryCode)
+      airline.getBases().groupBy(_.airport.countryCode).foreach {
+        case (countryCode, bases) =>
+          val countryDelegatesRequired = bases.map(_.delegatesRequired).sum
+          val assignedDelegatesCount = delegateTaskCountry.count(c => c == countryCode)
+          val missingDelegates = countryDelegatesRequired - assignedDelegatesCount
+          if (missingDelegates > 0) {
+            println(s"${airline.id} - ${airline.name} : missing $missingDelegates delegates for $countryCode")
+            //patch
+            val delegateTask = DelegateTask.country(currentCycle, CountryCache.getCountry(countryCode).get)
+            val newDelegates = (0 until missingDelegates).map(_ => BusyDelegate(airline, delegateTask, None))
+            DelegateSource.saveBusyDelegates(newDelegates.toList)
+          }
+      }
+    }
+    print("Done!")
+  }
+
+
+}

--- a/airline-web/app/controllers/CampaignApplication.scala
+++ b/airline-web/app/controllers/CampaignApplication.scala
@@ -138,7 +138,7 @@ class CampaignApplication @Inject()(cc: ControllerComponents) extends AbstractCo
           //save delegates
           val existingDelegates : List[BusyDelegate] = DelegateSource.loadBusyDelegatesByCampaigns(List(campaign)).getOrElse(campaign, List.empty).sortBy(_.assignedTask.getStartCycle)
           val delta = delegateCount - existingDelegates.length
-          if (delegateCount >= 0 && delta <= airline.getDelegateInfo().availableCount) {
+          if (delegateCount >= 0 && delta <= airline.getDelegateInfo().permanentAvailableCount) {
             if (delta < 0) { //unassign the most junior ones first
               existingDelegates.takeRight(delta * -1).foreach { unassigningDelegate =>
                 DelegateSource.deleteBusyDelegateByCriteria(List(("id", "=", unassigningDelegate.id)))

--- a/airline-web/app/controllers/DelegateApplication.scala
+++ b/airline-web/app/controllers/DelegateApplication.scala
@@ -30,7 +30,7 @@ class DelegateApplication @Inject()(cc: ControllerComponents) extends AbstractCo
       BadRequest(s"Require $delegatesRequired but trying to set to $delegateCount")
     } else {
       val delta = delegateCount - existingDelegates.length
-      if (delegateCount >= 0 && delta <= airline.getDelegateInfo().availableCount) {
+      if (delegateCount >= 0 && delta <= airline.getDelegateInfo().permanentAvailableCount) {
         if (delta < 0) { //unassign the most junior ones first
           existingDelegates.takeRight(delta * -1).foreach { unassigningDelegate =>
             DelegateSource.deleteBusyDelegateByCriteria(List(("id", "=", unassigningDelegate.id)))

--- a/airline-web/app/controllers/package.scala
+++ b/airline-web/app/controllers/package.scala
@@ -719,8 +719,13 @@ package object controllers {
 
   implicit object DelegateInfoWrites extends Writes[DelegateInfo] {
     def writes(delegateInfo : DelegateInfo): JsValue = {
-      var result = Json.obj("availableCount" -> delegateInfo.availableCount, "boost" -> delegateInfo.boost).asInstanceOf[JsObject]
       val currentCycle = CycleSource.loadCycle()
+      var boosts = Json.arr()
+      delegateInfo.boosts.foreach { boost =>
+        boosts = boosts.append(Json.obj("amount" -> boost.amount, "remainingCycles" -> (boost.expiryCycle.get - currentCycle)))
+      }
+
+      var result = Json.obj("availableCount" -> delegateInfo.availableCount, "permanentAvailableCount" -> delegateInfo.permanentAvailableCount, "boosts" -> boosts).asInstanceOf[JsObject]
       var busyDelegatesJson = Json.arr()
       val delegateWrites = new BusyDelegateWrites(currentCycle)
       delegateInfo.busyDelegates.foreach { busyDelegate =>

--- a/airline-web/app/views/index.scala.html
+++ b/airline-web/app/views/index.scala.html
@@ -4989,6 +4989,7 @@
 						  </div>
 					  </div>
 				  </div>
+				  <h5><span class="dot"/>Cannot assign temporary delegates awarded as bonus</h5>
 				  <h5><span class="dot"/>Require&nbsp;<span class="delegatesRequired"></span>&nbsp;delegates to maintain current bases in this country</h5>
 				  <h5><span class="dot"/>Each delegate level provides&nbsp;<span class="delegateMultiplier"></span>&nbsp;relationship points. Delegate starts at level 0 and progress over time. Hover over each delegate above to see details</h5>
 				  <div class="button" onclick="updateCountryDelegates()">Confirm</div>
@@ -5106,6 +5107,7 @@
 										</div>
 									</div>
 								</div>
+								<h5><span class="dot"/>Cannot assign temporary delegates awarded as bonus</h5>
 								<h5><span class="dot"/>Each delegate level provides&nbsp;<span class="loyaltyBonus"></span>&nbsp;loyalty. Delegate starts at level 0 and progress over time. Hover over each delegate above to see details</h5>
 							</div>
 						</div>

--- a/airline-web/public/javascripts/campaign.js
+++ b/airline-web/public/javascripts/campaign.js
@@ -21,7 +21,7 @@ function showCampaignModal() {
     }
 
     updateAirlineDelegateStatus($('#campaignModal div.delegateStatus'), function(delegateInfo) {
-            $('#campaignModal div.delegateSection').data("availableDelegates", delegateInfo.availableCount)
+            $('#campaignModal div.delegateSection').data("availableDelegates", delegateInfo.permanentAvailableCount)
         })
     $('#campaignModal div.delegateSection').data("delegatesRequired", 0)
     $('#campaignModal .campaignDetails').hide()

--- a/airline-web/public/javascripts/country.js
+++ b/airline-web/public/javascripts/country.js
@@ -459,7 +459,7 @@ function getCountryDelegatesSummary(countryCode) {
     $delegateSection.data("countryCode", countryCode)
 
     updateAirlineDelegateStatus($('#airlineCountryRelationshipModal div.delegateStatus'), function(delegateInfo) {
-        $delegateSection.data("availableDelegates", delegateInfo.availableCount)
+        $delegateSection.data("availableDelegates", delegateInfo.permanentAvailableCount)
     })
 
 	$.ajax({

--- a/airline-web/public/javascripts/delegate.js
+++ b/airline-web/public/javascripts/delegate.js
@@ -54,10 +54,12 @@ function refreshAirlineDelegateStatus($delegateStatusDiv, delegateInfo) {
     $delegateStatusDiv.empty()
     var availableDelegates = delegateInfo.availableCount
 
+    var delegateIcons = []
     //delegate info
     for (i = 0 ; i < availableDelegates; i ++) {
-        var delegateIcon = $('<img src="assets/images/icons/user-silhouette-available.png" title="Available Delegate"/>')
-        $delegateStatusDiv.append(delegateIcon)
+        var $delegateIconDiv = $('<div style="position: relative; display: inline-block;"><img src="assets/images/icons/user-silhouette-available.png" title="Available Delegate"/></div>')
+        $delegateIconDiv.expirable = true;
+        delegateIcons.push($delegateIconDiv)
     }
 
     $.each(delegateInfo.busyDelegates, function(index, busyDelegate) {
@@ -65,6 +67,7 @@ function refreshAirlineDelegateStatus($delegateStatusDiv, delegateInfo) {
         var $delegateIcon
         if (busyDelegate.completed) {
             $delegateIcon = $('<img src="assets/images/icons/user-silhouette-unavailable.png" title="' + busyDelegate.coolDown + ' week(s) cool down remaining. Previous task : ' + busyDelegate.taskDescription + '"/>')
+            $delegateIconDiv.expirable = true;
         } else {
             $delegateIcon = $('<img src="assets/images/icons/user-silhouette-busy.png" title="Busy with task - ' + busyDelegate.taskDescription + '"/>')
         }
@@ -76,7 +79,23 @@ function refreshAirlineDelegateStatus($delegateStatusDiv, delegateInfo) {
             $coolDownDiv.text(busyDelegate.coolDown)
             $delegateIconDiv.append($coolDownDiv)
         }
-        $delegateStatusDiv.append($delegateIconDiv)
+        delegateIcons.push($delegateIconDiv)
+    })
+
+
+    var iconIndex = delegateIcons.length //mark the available ones first
+    $.each(delegateInfo.boosts, function(index, boost) {
+        for (i = 0 ; i < boost.amount; i ++) {
+            while (--iconIndex > 0 && !delegateIcons[iconIndex].expirable) {
+                //find the first icon (traverse from the back) that can be marked as expirable
+            }
+            var $boostRemainingDiv = $("<div style='position: absolute; left: 1px; top: 0; background-color: #a4f5b0; color: #454544; font-size: 8px; font-weight: bold;' title='Boost expiring in " + boost.remainingCycles + " week(s)'>" + boost.remainingCycles + "</div>")
+            delegateIcons[iconIndex].append($boostRemainingDiv)
+        }
+    })
+
+    $.each(delegateIcons, function(index, $icon) {
+        $delegateStatusDiv.append($icon)
     })
 }
 


### PR DESCRIPTION
## Solution:
1. the sim no longer purge the busy delegate task on delegates obtained by boost - hence we would not "remove" delegates assigned to country/campaign when the boost expire - this would have the desirable result of available delegates going negative if necessary
2. introduce `permanentAvailableCount` for DelegateInfo, which remove delegates from boost (if not occupied), such number would also prevent assigning delegates to permanent tasks (like campaign, country)
3. Add to UI indicator of bonus delegate expiration
4. Added a one-time patch to force assign country delegates if they are missing