### PR TITLE
Increase Powerhouse pop effect

### DIFF
--- a/airline-data/src/main/scala/com/patson/model/AirlineBaseSpecialization.scala
+++ b/airline-data/src/main/scala/com/patson/model/AirlineBaseSpecialization.scala
@@ -54,7 +54,7 @@ object AirlineBaseSpecialization extends Enumeration {
       Computation.computeIncomeLevelBoostFromPercentage(airport.baseIncome, minIncomeBoost, percentageBoost)
     }
     def populationBoost(airport : Airport) = {
-      Math.min(Math.floor(minPopulationBoost + airport.baseIncome * ((maxPopulationBoost - minPopulationBoost) / richCountryThreshold)), maxPopulationBoost)
+      Math.max(Math.floor(maxPopulationBoost - airport.baseIncome * ((maxPopulationBoost - minPopulationBoost) / richCountryThreshold)), minPopulationBoost)
     }
     override def descriptions(airport : Airport) =  {
       List(s"Increase population by $populationBoost", s"Increase income level by ${incomeLevelBoost(airport)}")

--- a/airline-data/src/main/scala/com/patson/model/AirlineBaseSpecialization.scala
+++ b/airline-data/src/main/scala/com/patson/model/AirlineBaseSpecialization.scala
@@ -44,12 +44,17 @@ object AirlineBaseSpecialization extends Enumeration {
     override val label = "Powerhouse"
     override val free = true
     override val scaleRequirement : Int = 14
-    val populationBoost = 30000
     private[this] val minIncomeBoost = 3000 //should at least boost income by $3000
     private[this] val percentageBoost = 20 //20% if lower than minIncomeBoost then minIncomeBoost
+    private[this] val minPopulationBoost = 200_000 // for income richCountryThreshold and above countries
+    private[this] val maxPopulationBoost = 1_000_000 // for income 0 countries
+    private[this] val richCountryThreshold = 50_000 
 
     def incomeLevelBoost(airport : Airport) = {
       Computation.computeIncomeLevelBoostFromPercentage(airport.baseIncome, minIncomeBoost, percentageBoost)
+    }
+    def populationBoost(airport : Airport) = {
+      Math.min(Math.floor(minPopulationBoost + airport.baseIncome * ((maxPopulationBoost - minPopulationBoost) / richCountryThreshold)), maxPopulationBoost)
     }
     override def descriptions(airport : Airport) =  {
       List(s"Increase population by $populationBoost", s"Increase income level by ${incomeLevelBoost(airport)}")

--- a/airline-data/src/main/scala/com/patson/model/Airport.scala
+++ b/airline-data/src/main/scala/com/patson/model/Airport.scala
@@ -89,7 +89,7 @@ case class Airport(iata : String, icao : String, name : String, latitude : Doubl
             val powerHouseSpec = spec.asInstanceOf[PowerhouseSpecialization]
             val boost = boostType match {
               case AirportBoostType.INCOME => powerHouseSpec.incomeLevelBoost(Airport.this)
-              case AirportBoostType.POPULATION => powerHouseSpec.populationBoost
+              case AirportBoostType.POPULATION => powerHouseSpec.populationBoost(Airport.this)
               case _ => 0
             }
 


### PR DESCRIPTION
Powerhouse adds 1 million pop to an airport with 0 raw income in this, decreasing down to 200 thousand when the airport reaches 50,000 raw income.

