### PR TITLE
Don't count intercontinental routes for free routes

### DIFF
--- a/airline-web/app/controllers/NegotiationUtil.scala
+++ b/airline-web/app/controllers/NegotiationUtil.scala
@@ -408,7 +408,7 @@ object NegotiationUtil {
     val finalRequirementValue = fromAirportRequirementValue + toAirportRequirementValue
 
     //check for freebie bonus
-    if (airlineLinks.length < FREE_LINK_THRESHOLD &&
+    if (airlineLinks.filter(link => FlightType.getCategory(link.flightType) != FlightCategory.INTERCONTINENTAL).length < FREE_LINK_THRESHOLD &&
       newFrequency <= FREE_LINK_FREQUENCY_THRESHOLD &&  //to prevent many small increase
       finalRequirementValue < FREE_LINK_DIFFICULTY_THRESHOLD &&
       FlightType.getCategory(newLink.flightType) != FlightCategory.INTERCONTINENTAL


### PR DESCRIPTION
The current system counts intercontinental routes as routes for the purpose of giving free links, even though they do not get the bonus, so if you make an intercontinental route, you "waste" a free route. This filters out intercontinental routes before counting them, so this doesn't happen.