### PR TITLE
Check existing base when upgrading

### DIFF
--- a/airline-web/app/controllers/AirlineApplication.scala
+++ b/airline-web/app/controllers/AirlineApplication.scala
@@ -270,6 +270,15 @@ class AirlineApplication @Inject()(cc: ControllerComponents) extends AbstractCon
       return Some("Not enough cash to build/upgrade the base")
     }
 
+    val existingBase = airline.getBases().find(_.airport.id == targetBase.airport.id)
+    if (existingBase != undefined) {
+      if (targetBase.scale != existingBase.scale + 1) {
+        return Some(s"Can only upgrade base to level ${existingBase.scale + 1}")
+      }
+    } else if (targetBase.scale != 1) {
+      return Some(s"Base does not exist yet, can only build level 1 base")
+    }
+
     if (targetBase.scale == 1) { //building something new
       if (airline.getHeadQuarter().isDefined) { //building non-HQ
         AllianceSource.loadAllianceMemberByAirline(airline).filter(_.role != AllianceRole.APPLICANT).foreach { allianceMember =>


### PR DESCRIPTION
This rejects trying to upgrade more than 1 level at a time, rejects creating anything other than a level 1 base in airports without a base. Fixes some bugs such as:

- It is possible to build level 0 bases which have no staff but let you plan routes
- It is possible to skip levels when upgrading