### PR TITLE
To address the minimized config exploit

### DIFF
--- a/airline-data/src/main/scala/com/patson/model/Link.scala
+++ b/airline-data/src/main/scala/com/patson/model/Link.scala
@@ -98,6 +98,10 @@ case class Link(from : Airport, to : Airport, airline: Airline, price : LinkClas
     getOfficeStaffRequired(from, to, futureFrequency(), futureCapacity())
   }
 
+  lazy val getFutureOfficeStaffMinimizedRequired : Int = { //yike, to counter people that exploit the min airplane config
+    getOfficeStaffRequired(from, to, futureFrequency(), futureCapacity(minimized = true))
+  }
+
   lazy val getFutureOfficeStaffBreakdown : StaffBreakdown = {
     getOfficeStaffBreakdown(from, to, futureFrequency(), futureCapacity())
   }
@@ -134,10 +138,13 @@ case class Link(from : Airport, to : Airport, airline: Airline, price : LinkClas
     frequencyByClassLoaded = true
   }
 
-  def futureCapacity() = {
+  def futureCapacity(minimized : Boolean = false) = {
     var futureCapacity = LinkClassValues.getInstance()
     assignedAirplanes.foreach {
-      case(airplane, assignment) => futureCapacity = futureCapacity + (LinkClassValues(airplane.configuration.economyVal, airplane.configuration.businessVal, airplane.configuration.firstVal) * assignment.frequency)
+      case(airplane, assignment) => {
+        val configuration = if (minimized) airplane.configuration.minimized else airplane.configuration
+        futureCapacity = futureCapacity + (LinkClassValues(configuration.economyVal, configuration.businessVal, configuration.firstVal) * assignment.frequency)
+      }
     }
     futureCapacity
   }

--- a/airline-data/src/main/scala/com/patson/model/airplane/AirplaneConfiguration.scala
+++ b/airline-data/src/main/scala/com/patson/model/airplane/AirplaneConfiguration.scala
@@ -1,8 +1,14 @@
 package com.patson.model.airplane
 
-import com.patson.model.{AbstractLinkClassValues, Airline}
+import com.patson.model.{AbstractLinkClassValues, Airline, BUSINESS, FIRST, LinkClassValues}
 
 case class AirplaneConfiguration(economyVal : Int, businessVal : Int, firstVal : Int, airline : Airline, model : Model, isDefault : Boolean, var id : Int = 0) extends AbstractLinkClassValues(economyVal, businessVal, firstVal) {
+  lazy val minimized : AirplaneConfiguration = { //config that has least capacity
+    val minimizedFirst = (model.capacity / FIRST.spaceMultiplier).toInt
+    val minimizedBusiness = ((model.capacity - minimizedFirst * FIRST.spaceMultiplier) / BUSINESS.spaceMultiplier).toInt
+    //no eco as user can lock econ to zero
+    AirplaneConfiguration(0, minimizedBusiness, minimizedFirst, airline, model, isDefault)
+  }
 }
 
 object AirplaneConfiguration {

--- a/airline-web/app/controllers/NegotiationUtil.scala
+++ b/airline-web/app/controllers/NegotiationUtil.scala
@@ -96,15 +96,15 @@ object NegotiationUtil {
 
     val officeStaffCount : Int = baseOption.map(_.getOfficeStaffCapacity).getOrElse(0)
     val airlineLinksFromThisAirport = airlineLinks.filter(link => link.from.id == airport.id && (isNewLink || link.id != existingLinkOption.get.id))
-    val currentOfficeStaffUsed = airlineLinksFromThisAirport.map(_.getFutureOfficeStaffRequired).sum
-    val newOfficeStaffRequired = newLink.getFutureOfficeStaffRequired
+    val currentOfficeStaffUsed = airlineLinksFromThisAirport.map(_.getFutureOfficeStaffMinimizedRequired).sum
+    val newOfficeStaffRequired = newLink.getFutureOfficeStaffMinimizedRequired
     val newTotal = currentOfficeStaffUsed + newOfficeStaffRequired
 
     if (newTotal < officeStaffCount) {
-      requirements.append(NegotiationRequirement(STAFF_CAP, 0, s"Requires ${newOfficeStaffRequired} office staff, within your base capacity : ${newTotal} / ${officeStaffCount}"))
+      requirements.append(NegotiationRequirement(STAFF_CAP, 0, s"Requires ${newOfficeStaffRequired} office staff (minimized), within your base capacity : ${newTotal} / ${officeStaffCount}"))
     } else {
       val requirement = (newTotal - officeStaffCount).toDouble / 10
-      requirements.append(NegotiationRequirement(STAFF_CAP, requirement, s"Requires ${newOfficeStaffRequired} office staff, over your base capacity : ${newTotal} / ${officeStaffCount}"))
+      requirements.append(NegotiationRequirement(STAFF_CAP, requirement, s"Requires ${newOfficeStaffRequired} office staff (minimized), over your base capacity : ${newTotal} / ${officeStaffCount}"))
     }
 
     val mutualRelationship = CountrySource.getCountryMutualRelationship(newLink.from.countryCode, newLink.to.countryCode)


### PR DESCRIPTION
People exploit the minimized config loophole (by changing all airplane config to first class only) to get negotiation advantage.

After discusion with admin, the easiest to implement and least impact change is to take minimized config when doing the negotiation calculation.

Im very sad now...we have to put in ugly code logic that is confusing simply because some players like exploiting the game and fixing the loophole get other players calling it unfair...