### PR TITLE
Show whether airport allows int-int transfers in popup

### DIFF
--- a/airline-web/app/views/index.scala.html
+++ b/airline-web/app/views/index.scala.html
@@ -3581,7 +3581,7 @@
     <div style="display: none; width: 100%; white-space: normal;" id="airportPopup" class="mapPopup">
     	<input type="hidden" id="airportPopupId">
     	<div>
-    		<h4><span id="airportPopupName"></span>&nbsp;(<span id="airportPopupIata"></span>)</h4>
+    		<h4 style="margin-bottom: 0px"><span id="airportPopupName"></span>&nbsp;(<span id="airportPopupIata"></span>)&nbsp;<span id="airportPopupCustomsIcon" style="vertical-align: -4px;"></span></h4>
     	</div>
 		<h5><span id="airportPopupCity"></span>(<span id="airportPopupZone"></span>)</h5>
     	<div id="airportIcons" class="airportFeatures">

--- a/airline-web/public/javascripts/airport.js
+++ b/airline-web/public/javascripts/airport.js
@@ -677,6 +677,7 @@ function addMarkers(airports) {
 				  updateBaseInfo(this.airport.id)
 			  }
 			  $("#airportPopupName").text(this.airport.name)
+			  $("#airportPopupCustomsIcon").html(getOpennessIcon(loadedCountriesByCode[this.airport.countryCode].openness))
 			  $("#airportPopupIata").text(this.airport.iata)
 			  $("#airportPopupCity").html(this.airport.city + "&nbsp;" + getCountryFlagImg(this.airport.countryCode))
 			  $("#airportPopupZone").text(zoneById[this.airport.zone])

--- a/airline-web/public/javascripts/gadgets.js
+++ b/airline-web/public/javascripts/gadgets.js
@@ -398,6 +398,20 @@ function getOpennessSpan(openness) {
 	
 }
 
+
+function getOpennessIcon(openness) {
+	var description
+	var icon
+	if (openness >= 7) {
+		description = "Opened Market"
+		icon = "globe--plus.png"
+	} else {
+		description = "No International Connection"
+		icon = "globe--exclamation.png"
+	return "<img src='assets/images/icons/" + icon + "' title='" + description + "'/>"
+}
+
+
 function scrollToRow($matchingRow, $container) {
     var row = $matchingRow[0]
     var baseOffset = $container.find(".table-row")[0].offsetTop //somehow first row is not 0...


### PR DESCRIPTION
This displays a globe besides the name of the airport that shows whether the airport allows international transfers or not. Taken from MyFly Club.

![image](https://github.com/user-attachments/assets/779924bb-f44b-4bf9-8bf1-fd1e19dbedfa)
