### PR TITLE
Upgrade to Play 2.8.x

### DIFF
--- a/airline-data/src/main/scala/com/patson/data/Constants.scala
+++ b/airline-data/src/main/scala/com/patson/data/Constants.scala
@@ -73,7 +73,7 @@ object Constants {
   val AIRLINE_MODIFIER_INDEX_PREFIX = "airline_modifier_index_"
   val AIRLINE_MODIFIER_PROPERTY_TABLE = "airline_modifier_property"
 
-  
+
   val INCOME_TABLE = "income"
   val CASH_FLOW_TABLE = "cash_flow"
   val AIRLINE_LOGO_TABLE = "airline_logo"
@@ -176,7 +176,7 @@ object Constants {
   //Christmas Event
   val SANTA_CLAUS_INFO_TABLE = "santa_claus_info"
   val SANTA_CLAUS_GUESS_TABLE = "santa_claus_guess"
-  
+
 //  val DATABASE_CONNECTION = "jdbc:sqlite:../airline-data/db/default.db"
 //  val DB_DRIVER = "org.sqlite.JDBC"
   val configFactory = ConfigFactory.load()
@@ -192,5 +192,5 @@ object Constants {
   val DATABASE_PASSWORD = if (configFactory.hasPath("mysqldb.password")) configFactory.getString("mysqldb.password") else "admin"
 
   println(s"!!!!!!!!!!!!!!!FINAL DB str $DATABASE_CONNECTION with user $DATABASE_USER")
-  
+
 }

--- a/airline-web/app/controllers/AirplaneApplication.scala
+++ b/airline-web/app/controllers/AirplaneApplication.scala
@@ -34,7 +34,7 @@ class AirplaneApplication @Inject()(cc: ControllerComponents) extends AbstractCo
       result
     }
   }
-  
+
   implicit object AirplaneWithAssignedLinkWrites extends Writes[(Airplane, LinkAssignments)] {
     def writes(airplaneWithAssignedLink : (Airplane, LinkAssignments)): JsValue = {
       val airplane = airplaneWithAssignedLink._1
@@ -76,7 +76,7 @@ class AirplaneApplication @Inject()(cc: ControllerComponents) extends AbstractCo
   case class ModelWithDiscounts(originalModel : Model, discounts : List[ModelDiscount])
 
   sealed case class AirplanesByModel(model : Model, assignedAirplanes : List[Airplane], availableAirplanes : List[Airplane], constructingAirplanes: List[Airplane])
-  
+
   object AirplanesByModelWrites extends Writes[List[AirplanesByModel]] {
     def writes(airplanesByModelList: List[AirplanesByModel]): JsValue = {
       var result = Json.obj()
@@ -158,7 +158,7 @@ class AirplaneApplication @Inject()(cc: ControllerComponents) extends AbstractCo
     }
     result
   }
-  
+
   def getAirplaneModelsByAirline(airlineId : Int) = AuthenticatedAirline(airlineId) { request =>
     val originalModels = ModelSource.loadAllModels()
     val originalModelsById = originalModels.map(model => (model.id, model)).toMap
@@ -204,7 +204,7 @@ class AirplaneApplication @Inject()(cc: ControllerComponents) extends AbstractCo
 
     Ok(result)
   }
-  
+
   def getRejections(models : List[Model], airline : Airline) : Map[Model, Option[String]] = {
     val allManufacturingCountries = models.map(_.countryCode).toSet
 
@@ -218,16 +218,16 @@ class AirplaneApplication @Inject()(cc: ControllerComponents) extends AbstractCo
     models.map { model =>
       (model, getRejection(model, 1, countryRelations(model.countryCode), ownedModels, airline))
     }.toMap
-    
+
   }
-  
+
   def getRejection(model: Model, quantity : Int, airline : Airline) : Option[String] = {
     val relationship = AirlineCountryRelationship.getAirlineCountryRelationship(model.countryCode, airline)
 
     val ownedModels = AirplaneOwnershipCache.getOwnership(airline.id).map(_.model).toSet
     getRejection(model, quantity, relationship, ownedModels, airline)
   }
-  
+
   def getRejection(model: Model, quantity : Int, relationship : AirlineCountryRelationship, ownedModels : Set[Model], airline : Airline) : Option[String]= {
     if (airline.getHeadQuarter().isEmpty) { //no HQ
       return Some("Must build HQs before purchasing any airplanes")
@@ -248,10 +248,10 @@ class AirplaneApplication @Inject()(cc: ControllerComponents) extends AbstractCo
     if (cost > airline.getBalance()) {
       return Some("Not enough cash to purchase this airplane model")
     }
-    
+
     return None
   }
-  
+
   def getUsedRejections(usedAirplanes : List[Airplane], model : Model, airline : Airline) : Map[Airplane, String] = {
     if (airline.getHeadQuarter().isEmpty) { //no HQ
       return usedAirplanes.map((_, "Must build HQs before purchasing any airplanes")).toMap
@@ -267,7 +267,7 @@ class AirplaneApplication @Inject()(cc: ControllerComponents) extends AbstractCo
       val rejection = s"Cannot buy used airplane of " + model.name + s" until your relationship with ${CountryCache.getCountry(model.countryCode).get.name} is improved to at least ${Model.BUY_RELATIONSHIP_THRESHOLD}"
       return usedAirplanes.map((_, rejection)).toMap
     }
-    
+
     val ownedModels = AirplaneOwnershipCache.getOwnership(airline.id).map(_.model).toSet
     val ownedModelFamilies = ownedModels.map(_.family)
     if (!ownedModelFamilies.contains(model.family) && ownedModelFamilies.size >= airline.airlineGrade.getModelFamilyLimit) {
@@ -275,11 +275,11 @@ class AirplaneApplication @Inject()(cc: ControllerComponents) extends AbstractCo
       val rejection = "Can only own up to " + airline.airlineGrade.getModelFamilyLimit + " different airplane " + familyToken + " at current airline grade"
       return usedAirplanes.map((_, rejection)).toMap
     }
-    
+
     val rejections = scala.collection.mutable.Map[Airplane, String]()
     usedAirplanes.foreach { airplane =>
       if (airplane.dealerValue > airline.getBalance()) {
-         rejections.put(airplane, "Not enough cash to purchase this airplane")  
+         rejections.put(airplane, "Not enough cash to purchase this airplane")
       }
     }
     return rejections.toMap
@@ -362,12 +362,12 @@ class AirplaneApplication @Inject()(cc: ControllerComponents) extends AbstractCo
     }
   }
 
-  
+
   def getUsedAirplanes(airlineId : Int, modelId : Int) = AuthenticatedAirline(airlineId) { request =>
       ModelSource.loadModelById(modelId) match {
-        case Some(model) => 
+        case Some(model) =>
           val usedAirplanes = AirplaneSource.loadAirplanesCriteria(List(("a.model", modelId), ("is_sold", true)))
-          
+
           val rejections = getUsedRejections(usedAirplanes, model, request.user)
           var result = Json.arr()
           usedAirplanes.foreach { airplane =>
@@ -381,7 +381,7 @@ class AirplaneApplication @Inject()(cc: ControllerComponents) extends AbstractCo
         case None => BadRequest("model not found")
       }
   }
-  
+
   def buyUsedAirplane(airlineId : Int, airplaneId : Int, homeAirportId : Int, configurationId : Int) = AuthenticatedAirline(airlineId) { request =>
       this.synchronized {
         AirplaneSource.loadAirplaneById(airplaneId) match {
@@ -435,9 +435,9 @@ class AirplaneApplication @Inject()(cc: ControllerComponents) extends AbstractCo
         }
       }
   }
-  
-  
-  
+
+
+
   def getAirplane(airlineId : Int, airplaneId : Int) =  AuthenticatedAirline(airlineId) {
     AirplaneSource.loadAirplaneById(airplaneId) match {
       case Some(airplane) =>
@@ -452,7 +452,7 @@ class AirplaneApplication @Inject()(cc: ControllerComponents) extends AbstractCo
         BadRequest("airplane not found")
     }
   }
-  
+
   def sellAirplane(airlineId : Int, airplaneId : Int) = AuthenticatedAirline(airlineId) {
     AirplaneSource.loadAirplaneById(airplaneId) match {
       case Some(airplane) =>
@@ -492,12 +492,12 @@ class AirplaneApplication @Inject()(cc: ControllerComponents) extends AbstractCo
         BadRequest("airplane not found")
     }
   }
-  
+
   def replaceAirplane(airlineId : Int, airplaneId : Int) = AuthenticatedAirline(airlineId) { request =>
     AirplaneSource.loadAirplaneById(airplaneId) match {
       case Some(airplane) =>
         if (airplane.owner.id == airlineId) {
-          val currentCycle = CycleSource.loadCycle
+          val currentCycle = CycleSource.loadCycle()
           if (!airplane.isReady) {
             BadRequest("airplane is not yet constructed")
           } else if (airplane.purchasedCycle > (currentCycle - airplane.model.constructionTime)) {
@@ -544,7 +544,7 @@ class AirplaneApplication @Inject()(cc: ControllerComponents) extends AbstractCo
         BadRequest("airplane not found")
     }
   }
-  
+
   def addAirplane(airlineId : Int, modelId : Int, quantity : Int, homeAirportId : Int, configurationId : Int) = AuthenticatedAirline(airlineId) { request =>
     ModelSource.loadModelById(modelId) match {
       case None =>

--- a/airline-web/app/controllers/AirportAssetApplication.scala
+++ b/airline-web/app/controllers/AirportAssetApplication.scala
@@ -142,7 +142,7 @@ class AirportAssetApplication @Inject()(cc: ControllerComponents) extends Abstra
 
   def getAirportAssetsWithAirline(airlineId : Int) = AuthenticatedAirline(airlineId) { request =>
     val assets = AirportAssetSource.loadAirportAssetsByAirline(airlineId)
-    Ok(Json.toJson(assets)(Writes.traversableWrites(OwnedAirportAssetWrites)))
+    Ok(Json.toJson(assets)(Writes.iterableWrites(OwnedAirportAssetWrites)))
   }
 
   def getAirportAssetDetailsWithoutAirline(assetId : Int) = Action { request =>

--- a/airline-web/app/controllers/AlertApplication.scala
+++ b/airline-web/app/controllers/AlertApplication.scala
@@ -43,27 +43,27 @@ class AlertApplication @Inject()(cc: ControllerComponents) extends AbstractContr
       "duration" -> JsNumber(alert.duration),
       "cycleDelta" -> JsNumber(alert.cycle - currentCycle)
       ))
-      
+
       alert.targetId.foreach { targetId =>
         result = result + ("targetId" -> JsNumber(targetId))
       }
-      
+
       result
     }
   }
-  
-  
+
+
   val LOG_RANGE = 100 //load 100 weeks worth of alerts
-  
-  
+
+
   def getAlerts(airlineId : Int) = AuthenticatedAirline(airlineId) { request =>
     val alerts = AlertSource.loadAlertsByAirline(request.user.id).sortBy(_.cycle)(Ordering[Int].reverse)
     //Ok(Json.toJson(alerts)(Writes.traversableWrites(AlertWrites(CycleSource.loadCycle()))))
     implicit val alertWrites = AlertWrites(CycleSource.loadCycle())
     Ok(Json.toJson(alerts))
   }
-  
-  
 
-  
+
+
+
 }

--- a/airline-web/app/controllers/AllianceApplication.scala
+++ b/airline-web/app/controllers/AllianceApplication.scala
@@ -35,7 +35,7 @@ class AllianceApplication @Inject()(cc: ControllerComponents) extends AbstractCo
       })
       ))
   }
-  
+
   implicit object AllianceMemberWrites extends Writes[AllianceMember] {
     //case class AllianceMember(alliance: Alliance, airline : Airline, role : AllianceRole.Value, joinedCycle : Int)
     def writes(allianceMember: AllianceMember): JsValue = JsObject(List(
@@ -51,16 +51,16 @@ class AllianceApplication @Inject()(cc: ControllerComponents) extends AbstractCo
       "allianceId" -> JsNumber(allianceMember.allianceId),
       "allianceName" -> JsString(AllianceCache.getAlliance(allianceMember.allianceId).get.name)))
   }
-  
-  
-  
+
+
+
   implicit object HistoryWrites extends Writes[AllianceHistory] {
     //case class AllianceHistory(allianceName : String, airline : Airline, event : AllianceEvent.Value, cycle : Int, var id : Int = 0)
     def writes(history: AllianceHistory): JsValue = JsObject(List(
       "cycle" -> JsNumber(history.cycle),
       "description" -> JsString(getHistoryDescription(history))
       ))
-      
+
     def getHistoryDescription(history : AllianceHistory) : String = {
       val eventAction = AllianceUtil.getAllianceEventText(history.event)
       history.airline.name + " " + eventAction + " " + history.allianceName
@@ -147,25 +147,25 @@ class AllianceApplication @Inject()(cc: ControllerComponents) extends AbstractCo
 
     case class FormAlliance(allianceName : String)
   val formAllianceForm : Form[FormAlliance] = Form(
-    
+
     // Define a mapping that will handle User values
     mapping(
       "allianceName" -> text(minLength = 1, maxLength = 50).verifying(
         "Alliance name can only contain space and characters",
         allianceName => allianceName.forall(char => char.isLetter || char == ' ') && !"".equals(allianceName.trim())).verifying(
-        "This Alliance name  is not available",  
+        "This Alliance name  is not available",
         allianceName => !AllianceSource.loadAllAlliances(false).map { _.name.toLowerCase() }.contains(allianceName.toLowerCase())
       )
     )
     { //binding
-      (allianceName) => FormAlliance(allianceName.trim) 
-    } 
+      (allianceName) => FormAlliance(allianceName.trim)
+    }
     { //unbinding
       formAlliance => Some(formAlliance.allianceName)
     }
   )
-  
-  
+
+
   def getAirlineAllianceDetails(airlineId : Int) = AuthenticatedAirline(airlineId) { request =>
     var result = Json.obj()
     AllianceSource.loadAllianceMemberByAirline(request.user) match {
@@ -185,9 +185,9 @@ class AllianceApplication @Inject()(cc: ControllerComponents) extends AbstractCo
         }
         result = result + ("isAdmin" -> JsBoolean(AllianceRole.isAdmin(allianceMember.role)))
 
-      case None => //do nothing 
+      case None => //do nothing
     }
-    
+
     val history = AllianceSource.loadAllianceHistoryByAirline(airlineId)
     if (!history.isEmpty) {
       result = result + ("history" -> Json.toJson(history.sortBy(_.cycle)(Ordering.Int.reverse)))
@@ -200,7 +200,7 @@ class AllianceApplication @Inject()(cc: ControllerComponents) extends AbstractCo
   }
 
   def formAlliance(airlineId : Int) = AuthenticatedAirline(airlineId) { implicit request =>
-    formAllianceForm.bindFromRequest.fold(
+    formAllianceForm.bindFromRequest().fold(
       // Form has errors, redisplay it
       erroredForm => Ok(Json.obj("rejection" -> JsString(erroredForm.error("allianceName").get.message))), { formAllianceInput =>
         //make sure the current airline is not in any alliance
@@ -226,15 +226,15 @@ class AllianceApplication @Inject()(cc: ControllerComponents) extends AbstractCo
       }
     )
   }
-  
-  
+
+
   def getAlliances(airlineId : Option[Int]) = Action { request =>
     val alliances : List[Alliance] = AllianceSource.loadAllAlliances(true)
-    
+
     var result = Json.arr()
-    
+
     val alliancesWithRanking : Map[Int, (Int, BigDecimal)] = AllianceRankingUtil.getRankings()
-    
+
     alliances.foreach {
       alliance =>
         val isCurrentMember = airlineId match {
@@ -260,21 +260,21 @@ class AllianceApplication @Inject()(cc: ControllerComponents) extends AbstractCo
             //allianceJson = allianceJson + ("maxFrequencyBonus" -> JsNumber(Alliance.getMaxFrequencyBonus(ranking)))
           }
         }
-        
-        
-        
+
+
+
         val historyEntries : List[AllianceHistory] = AllianceSource.loadAllianceHistoryByAllianceName(alliance.name)
         allianceJson = allianceJson + ("history" -> Json.toJson(historyEntries.sortBy(_.cycle)(Ordering.Int.reverse)))
         result = result.append(allianceJson)
     }
-    
+
     Ok(result)
   }
-  
+
   object SimpleLinkWrites extends Writes[List[Link]] {
     def writes(links: List[Link]): JsValue =  {
       var result = Json.arr()
-      
+
       links.foreach { link =>
         var linkJson = JsObject(List(
         "id" -> JsNumber(link.id),
@@ -298,7 +298,7 @@ class AllianceApplication @Inject()(cc: ControllerComponents) extends AbstractCo
         "capacity" -> Json.toJson(link.capacity),
         "flightType" -> JsString(link.flightType.toString()),
         "flightCode" -> JsString(LinkUtil.getFlightCode(link.airline, link.flightNumber))))
-        result = result.append(linkJson) 
+        result = result.append(linkJson)
       }
       result
     }
@@ -316,7 +316,7 @@ class AllianceApplication @Inject()(cc: ControllerComponents) extends AbstractCo
       result
     }
   }
-  
+
   def getAllAllianceDetails(allianceId : Int) = Action { request =>
     AllianceCache.getAlliance(allianceId, true) match {
       case None => NotFound("Alliance with " + allianceId + " is not found")
@@ -505,7 +505,7 @@ class AllianceApplication @Inject()(cc: ControllerComponents) extends AbstractCo
         getApplyRejection(request.user, alliance) match {
             case Some(rejection) => BadRequest(rejection)
             case None => //ok
-              val currentCycle = CycleSource.loadCycle
+              val currentCycle = CycleSource.loadCycle()
               val newMember = AllianceMember(allianceId = alliance.id, airline = request.user, role = APPLICANT, joinedCycle = currentCycle)
               AllianceSource.saveAllianceMember(newMember)
               val history = AllianceHistory(allianceName = alliance.name, airline = request.user, event = APPLY_ALLIANCE, cycle = currentCycle)
@@ -545,7 +545,7 @@ class AllianceApplication @Inject()(cc: ControllerComponents) extends AbstractCo
   }
 
   def addToAlliance(airlineId : Int, targetAirlineId : Int) = AuthenticatedAirline(airlineId) { implicit request =>
-       val currentCycle = CycleSource.loadCycle
+       val currentCycle = CycleSource.loadCycle()
 
        AllianceSource.loadAllianceMemberByAirline(request.user) match {
           case None => BadRequest("Current airline " + request.user + " cannot add airline id "+ targetAirlineId + " to alliance as current airline does not belong to any alliance")
@@ -583,7 +583,7 @@ class AllianceApplication @Inject()(cc: ControllerComponents) extends AbstractCo
   }
 
   def promoteMember(airlineId : Int, targetAirlineId : Int) = AuthenticatedAirline(airlineId) { implicit request =>
-    val currentCycle = CycleSource.loadCycle
+    val currentCycle = CycleSource.loadCycle()
     AllianceSource.loadAllianceMemberByAirline(request.user) match {
       case None => BadRequest("Current airline " + request.user + " cannot promote airline id " + targetAirlineId + " to alliance as current airline does not belong to any alliance")
       case Some(currentMember) =>
@@ -617,7 +617,7 @@ class AllianceApplication @Inject()(cc: ControllerComponents) extends AbstractCo
   }
 
   def demoteMember(airlineId : Int, targetAirlineId : Int) = AuthenticatedAirline(airlineId) { implicit request =>
-    val currentCycle = CycleSource.loadCycle
+    val currentCycle = CycleSource.loadCycle()
     AllianceSource.loadAllianceMemberByAirline(request.user) match {
       case None => BadRequest("Current airline " + request.user + " cannot demote airline id " + targetAirlineId + " to alliance as current airline does not belong to any alliance")
       case Some(currentMember) =>
@@ -644,43 +644,43 @@ class AllianceApplication @Inject()(cc: ControllerComponents) extends AbstractCo
     }
   }
 
-  
+
   def getApplyRejection(airline : Airline, alliance : Alliance) : Option[String] = {
     val approvedMembers = alliance.members.filter(_.role != AllianceRole.APPLICANT)
-    
-    if (airline.getHeadQuarter.isEmpty) { 
+
+    if (airline.getHeadQuarter().isEmpty) {
       return Some("Airline does not have headquarters")
     }
-    
+
     if (approvedMembers.size >= Alliance.MAX_MEMBER_COUNT) {
       return Some("Alliance has reached max member size " + Alliance.MAX_MEMBER_COUNT + " already")
     }
-    
-    
+
+
     val allAllianceHeadquarters = approvedMembers.flatMap(_.airline.getHeadQuarter).map(_.airport)
 
-    val airlineHeadquarters = airline.getHeadQuarter.get.airport
-    
+    val airlineHeadquarters = airline.getHeadQuarter().get.airport
+
     if (allAllianceHeadquarters.contains(airlineHeadquarters)) {
       return Some("One of the alliance members has Headquarters at " + getAirportText(airlineHeadquarters))
     }
-    
+
     val allAllianceBases = approvedMembers.flatMap { _.airline.getBases().filter( !_.headquarter) }.map(_.airport)
-    val airlineBases = airline.getBases.filter(!_.headquarter).map(_.airport) 
+    val airlineBases = airline.getBases().filter(!_.headquarter).map(_.airport)
     val overlappingBases = allAllianceBases.filter(allianceBase => airlineBases.contains(allianceBase))
-   
+
 //     println("ALL " + allAllianceBases)
 //     println("YOURS " + airlineHeadquarters)
-    
+
     if (!overlappingBases.isEmpty) {
       var message = "Alliance members have overlapping airport bases: "
       overlappingBases.foreach { overlappingBase =>
         message += getAirportText(overlappingBase) + "; "
       }
-       
+
       return Some(message)
     }
-    
+
      AllianceSource.loadAllianceMemberByAirline(airline) match {
        case Some(allianceMember) =>
          if (allianceMember.allianceId != alliance.id) {
@@ -691,7 +691,7 @@ class AllianceApplication @Inject()(cc: ControllerComponents) extends AbstractCo
      }
     return None
   }
-  
+
   def getAirportText(airport : Airport) = {
     airport.city + " - " + airport.name
   }

--- a/airline-web/app/controllers/BankApplication.scala
+++ b/airline-web/app/controllers/BankApplication.scala
@@ -34,11 +34,11 @@ class BankApplication @Inject()(cc: ControllerComponents) extends AbstractContro
   )
 
   def viewLoans(airlineId : Int) = AuthenticatedAirline(airlineId) { request : AuthenticatedRequest[Any, Airline] =>
-    Ok(Json.toJson(BankSource.loadLoansByAirline(request.user.id))(Writes.traversableWrites(new LoanWrites(CycleSource.loadCycle()))))
+    Ok(Json.toJson(BankSource.loadLoansByAirline(request.user.id))(Writes.iterableWrites(new LoanWrites(CycleSource.loadCycle()))))
   }
-  
+
   def takeOutLoan(airlineId : Int) = AuthenticatedAirline(airlineId) { implicit request =>
-    val LoanRequest(requestedAmount, requestedTerm) = loanForm.bindFromRequest.get
+    val LoanRequest(requestedAmount, requestedTerm) = loanForm.bindFromRequest().get
     val loanReply = Bank.getMaxLoan(airlineId)
     val currentCycle = CycleSource.loadCycle()
     if (loanReply.rejectionOption.isDefined) {
@@ -59,18 +59,18 @@ class BankApplication @Inject()(cc: ControllerComponents) extends AbstractContro
       }
     }
   }
-  
+
   def getLoanOptions(airlineId : Int, loanAmount : Long) = AuthenticatedAirline(airlineId) { request =>
     val loanReply = Bank.getMaxLoan(request.user.id)
     if (loanAmount <= loanReply.maxLoan) {
       val options = Bank.getLoanOptions(loanAmount)
-      Ok(Json.toJson(options)(Writes.traversableWrites(new LoanWrites(CycleSource.loadCycle()))))
+      Ok(Json.toJson(options)(Writes.iterableWrites(new LoanWrites(CycleSource.loadCycle()))))
     } else {
       BadRequest("Borrowing [" + loanAmount + "] which is above limit [" + loanReply.maxLoan + "]")
     }
-    
+
   }
-  
+
   def getMaxLoan(airlineId : Int) = AuthenticatedAirline(airlineId) { request =>
     val loanReply = Bank.getMaxLoan(request.user.id)
     var result = Json.obj("maxAmount" -> JsNumber(loanReply.maxLoan)).asInstanceOf[JsObject]
@@ -79,15 +79,15 @@ class BankApplication @Inject()(cc: ControllerComponents) extends AbstractContro
     }
     Ok(result)
   }
-  
+
   def repayLoan(airlineId : Int, loanId : Int) = AuthenticatedAirline(airlineId) { request =>
     val currentCycle = CycleSource.loadCycle()
     BankSource.loadLoanById(loanId) match {
-      case Some(loan) => { 
+      case Some(loan) => {
         if (loan.airlineId != request.user.id) {
-          BadRequest("Cannot repay loan not owned by this airline") 
+          BadRequest("Cannot repay loan not owned by this airline")
         } else {
-          val balance = request.user.getBalance 
+          val balance = request.user.getBalance()
           if (balance < loan.earlyRepayment(currentCycle)) {
             BadRequest("Not enough cash to repay this loan")
           } else {

--- a/airline-web/app/controllers/LinkApplication.scala
+++ b/airline-web/app/controllers/LinkApplication.scala
@@ -44,16 +44,16 @@ class LinkApplication @Inject()(cc: ControllerComponents) extends AbstractContro
       val distance = Util.calculateDistance(fromAirport.latitude, fromAirport.longitude, toAirport.latitude, toAirport.longitude).toInt
       val rawQuality = json.\("quality").as[Int]
       val flightType = Computation.getFlightType(fromAirport, toAirport, distance)
-      
+
       val link = Link(fromAirport, toAirport, airline, LinkClassValues.getInstance(price), distance, LinkClassValues.getInstance(capacity), rawQuality, distance.toInt * 60 / 800, 1, flightType)
-      (json \ "id").asOpt[Int].foreach { link.id = _ } 
+      (json \ "id").asOpt[Int].foreach { link.id = _ }
       JsSuccess(link)
     }
   }
-  
-  
-  
-  
+
+
+
+
   implicit object LinkConsumptionFormat extends Writes[LinkConsumptionDetails] {
     def writes(linkConsumption: LinkConsumptionDetails): JsValue = {
 //      val fromAirport = AirportCache.getAirport(linkConsumption.fromAirportId)
@@ -89,7 +89,7 @@ class LinkApplication @Inject()(cc: ControllerComponents) extends AbstractContro
       "cancellationCount" -> JsNumber(linkConsumption.link.cancellationCount),
       "satisfaction" -> JsNumber(linkConsumption.satisfaction),
       "cycle" -> JsNumber(linkConsumption.cycle)))
-      
+
     }
   }
 
@@ -136,7 +136,7 @@ class LinkApplication @Inject()(cc: ControllerComponents) extends AbstractContro
       result
     }
   }
-  
+
   implicit object ModelPlanLinkInfoWrites extends Writes[ModelPlanLinkInfo] {
     def writes(modelPlanLinkInfo : ModelPlanLinkInfo): JsValue = {
       val jsObject = JsObject(List(
@@ -149,7 +149,7 @@ class LinkApplication @Inject()(cc: ControllerComponents) extends AbstractContro
       "flightMinutesRequired" -> JsNumber(modelPlanLinkInfo.flightMinutesRequired),
       "maxFrequency" -> JsNumber(modelPlanLinkInfo.maxFrequency),
       "isAssigned" -> JsBoolean(modelPlanLinkInfo.isAssigned)))
-      
+
       var airplaneArray = JsArray()
 
       modelPlanLinkInfo.airplanes.foreach {
@@ -162,7 +162,7 @@ class LinkApplication @Inject()(cc: ControllerComponents) extends AbstractContro
     }
   }
 
-  
+
   implicit object LinkExtendedInfoWrites extends Writes[LinkExtendedInfo] {
     def writes(entry: LinkExtendedInfo): JsValue = {
       val link = entry.link
@@ -196,7 +196,7 @@ class LinkApplication @Inject()(cc: ControllerComponents) extends AbstractContro
   }
 
   implicit object RouteWrites extends Writes[Route] {
-    def writes(route : Route): JsValue = { 
+    def writes(route : Route): JsValue = {
       Json.toJson(route.links)
     }
   }
@@ -220,7 +220,7 @@ class LinkApplication @Inject()(cc: ControllerComponents) extends AbstractContro
     }
   }
 
-  
+
   case class PlanLinkData(fromAirportId: Int, toAirportId: Int)
   val planLinkForm = Form(
     mapping(
@@ -228,17 +228,17 @@ class LinkApplication @Inject()(cc: ControllerComponents) extends AbstractContro
       "toAirportId" -> number
     )(PlanLinkData.apply)(PlanLinkData.unapply)
   )
-  
-  val countryByCode = CountrySource.loadAllCountries.map(country => (country.countryCode, country)).toMap
-  
+
+  val countryByCode = CountrySource.loadAllCountries().map(country => (country.countryCode, country)).toMap
+
   def addTestLink() = Action { request =>
     if (request.body.isInstanceOf[AnyContentAsJson]) {
       val newLink = request.body.asInstanceOf[AnyContentAsJson].json.as[Link](TestLinkReads)
       println("PUT (test)" + newLink)
-      
+
       LinkSource.saveLink(newLink) match {
         case Some(link) =>
-          Created(Json.toJson(link))      
+          Created(Json.toJson(link))
         case None => UnprocessableEntity("Cannot insert link")
       }
     } else {
@@ -259,7 +259,7 @@ class LinkApplication @Inject()(cc: ControllerComponents) extends AbstractContro
 
     val airline = request.user
 
-    if (incomingLink.getAssignedAirplanes.isEmpty) {
+    if (incomingLink.getAssignedAirplanes().isEmpty) {
       return BadRequest("Cannot insert link - no airplane assigned")
     }
 
@@ -274,7 +274,7 @@ class LinkApplication @Inject()(cc: ControllerComponents) extends AbstractContro
     }
 
     //validate slots
-    val airplanesForThisLink = incomingLink.getAssignedAirplanes
+    val airplanesForThisLink = incomingLink.getAssignedAirplanes()
     //validate all airplanes are same model
     val airplaneModels = airplanesForThisLink.foldLeft(Set[Model]())(_ + _._1.model) //should be just one element
     if (airplaneModels.size != 1) {
@@ -646,7 +646,7 @@ class LinkApplication @Inject()(cc: ControllerComponents) extends AbstractContro
 
 
   def planLink(airlineId : Int) = AuthenticatedAirline(airlineId)  { implicit request =>
-    val PlanLinkData(fromAirportId, toAirportId) = planLinkForm.bindFromRequest.get
+    val PlanLinkData(fromAirportId, toAirportId) = planLinkForm.bindFromRequest().get
     val airline = request.user
     preparePlanLink(airline, fromAirportId, toAirportId) match {
       case Right((fromAirport, toAirport)) => {
@@ -719,14 +719,14 @@ class LinkApplication @Inject()(cc: ControllerComponents) extends AbstractContro
           Pricing.computeStandardPrice(distance, Computation.getFlightType(fromAirport, toAirport, distance), FIRST))
 
         //adjust suggestedPrice with Lounge
-        toAirport.getLounge(airline.id, airline.getAllianceId, activeOnly = true).foreach { lounge =>
+        toAirport.getLounge(airline.id, airline.getAllianceId(), activeOnly = true).foreach { lounge =>
           suggestedPrice = LinkClassValues.getInstance(suggestedPrice(ECONOMY),
             (suggestedPrice(BUSINESS) / (1 + lounge.getPriceReduceFactor(distance))).toInt,
             (suggestedPrice(FIRST) / (1 + lounge.getPriceReduceFactor(distance))).toInt)
 
         }
 
-        fromAirport.getLounge(airline.id, airline.getAllianceId, activeOnly = true).foreach { lounge =>
+        fromAirport.getLounge(airline.id, airline.getAllianceId(), activeOnly = true).foreach { lounge =>
           suggestedPrice = LinkClassValues.getInstance(suggestedPrice(ECONOMY),
             (suggestedPrice(BUSINESS) / (1 + lounge.getPriceReduceFactor(distance))).toInt,
             (suggestedPrice(FIRST) / (1 + lounge.getPriceReduceFactor(distance))).toInt)
@@ -879,7 +879,7 @@ class LinkApplication @Inject()(cc: ControllerComponents) extends AbstractContro
 
   def getRejectionReason(airline : Airline, fromAirport: Airport, toAirport : Airport, existingLink : Option[Link]) : Option[(String, RejectionType.Value)]= {
     import RejectionType._
-    if (airline.getCountryCode.isEmpty) {
+    if (airline.getCountryCode().isEmpty) {
       return Some(("Airline has no HQ!", NO_BASE))
     }
     val toCountryCode = toAirport.countryCode
@@ -966,7 +966,7 @@ class LinkApplication @Inject()(cc: ControllerComponents) extends AbstractContro
 //  def getVipRoutes() = Action {
 //    Ok(Json.toJson(RouteHistorySource.loadVipRoutes()))
 //  }
-  
+
   def getRelatedLinkConsumption(airlineId : Int, linkId : Int, cycleDelta : Int, selfOnly : Boolean, economy : Boolean, business : Boolean, first : Boolean) =  AuthenticatedAirline(airlineId) {
     LinkSource.loadFlightLinkById(linkId, LinkSource.SIMPLE_LOAD) match {
       case Some(link) => {
@@ -1195,7 +1195,7 @@ class LinkApplication @Inject()(cc: ControllerComponents) extends AbstractContro
 
       var overlappingLinksJson = Json.arr()
       overlappingLinks.filter(_.capacity.total > 0).foreach { overlappingLink => //only work on links that have capacity
-        overlappingLinksJson = overlappingLinksJson.append(Json.toJson(LinkSource.loadLinkConsumptionsByLinkId(overlappingLink.id, cycleCount))(Writes.traversableWrites(MinimumLinkConsumptionWrite)))
+        overlappingLinksJson = overlappingLinksJson.append(Json.toJson(LinkSource.loadLinkConsumptionsByLinkId(overlappingLink.id, cycleCount))(Writes.iterableWrites(MinimumLinkConsumptionWrite)))
         rivals += overlappingLink.airline
       }
 
@@ -1391,19 +1391,19 @@ class LinkApplication @Inject()(cc: ControllerComponents) extends AbstractContro
         }
       }
 
-      val linkChangesJson = Json.toJson(linkChanges)(Writes.traversableWrites(new LinkChangeToEventWrites(currentCycle, link))).as[JsArray]
+      val linkChangesJson = Json.toJson(linkChanges)(Writes.iterableWrites(new LinkChangeToEventWrites(currentCycle, link))).as[JsArray]
       result = result ++ linkChangesJson
     }
 
     //self alliance history
-    result = result ++ Json.toJson(AllianceSource.loadAllianceHistoryByAirline(airlineId).filter(_.cycle >= fromCycle).filter(entry => isRelevantAllianceHistoryEvent(entry.event)))(Writes.traversableWrites(new AllianceHistoryToEventWrites(currentCycle))).as[JsArray]
+    result = result ++ Json.toJson(AllianceSource.loadAllianceHistoryByAirline(airlineId).filter(_.cycle >= fromCycle).filter(entry => isRelevantAllianceHistoryEvent(entry.event)))(Writes.iterableWrites(new AllianceHistoryToEventWrites(currentCycle))).as[JsArray]
     //other airline alliance history (complicate if current airline left/joined during the period, for now just get the history of current alliance
     request.user.getAllianceId().foreach { allianceId =>
       AllianceSource.loadAllianceById(allianceId).foreach { alliance =>
         result = result ++
           Json.toJson(AllianceSource.loadAllianceHistoryByAllianceName(alliance.name).filter {
             entry => entry.cycle >= fromCycle && entry.airline.id != airlineId && isRelevantAllianceHistoryEvent(entry.event)
-          })(Writes.traversableWrites(new AllianceHistoryToEventWrites(currentCycle))).as[JsArray]
+          })(Writes.iterableWrites(new AllianceHistoryToEventWrites(currentCycle))).as[JsArray]
       }
     }
 
@@ -1570,7 +1570,7 @@ class LinkApplication @Inject()(cc: ControllerComponents) extends AbstractContro
 
 
     var result = Json.obj("negotiationInfo" -> Json.toJson(negotiationInfo)(NegotiationInfoWrites(incomingLink)),
-    "delegateInfo" -> Json.toJson(request.user.getDelegateInfo),
+    "delegateInfo" -> Json.toJson(request.user.getDelegateInfo()),
     "toAirport" -> Json.toJson(incomingLink.to),
     "fromAirport" -> Json.toJson(incomingLink.from))
 

--- a/airline-web/app/controllers/LinkUtil.scala
+++ b/airline-web/app/controllers/LinkUtil.scala
@@ -37,6 +37,6 @@ object LinkUtil {
   }
 
   def getFlightCode(airline : Airline, flightNumber : Int) = {
-    airline.getAirlineCode + " " + (1000 + flightNumber).toString.substring(1, 4)
+    airline.getAirlineCode() + " " + (1000 + flightNumber).toString.substring(1, 4)
   }
 }

--- a/airline-web/app/controllers/LogApplication.scala
+++ b/airline-web/app/controllers/LogApplication.scala
@@ -25,13 +25,13 @@ class LogApplication @Inject()(cc: ControllerComponents) extends AbstractControl
       "properties" -> Json.toJson(log.properties)
       ))
   }
-  
-  
+
+
   val LOG_RANGE = 100 //load 100 weeks worth of logs
-  
-  
+
+
   def getLogs(airlineId : Int) = AuthenticatedAirline(airlineId) { request =>
-    val cycle = CycleSource.loadCycle
+    val cycle = CycleSource.loadCycle()
     implicit val logWrites = LogWrites(cycle)
     Ok(Json.toJson(LogSource.loadLogsByAirline(request.user.id, cycle - Log.RETENTION_CYCLE).sortBy(_.cycle)(Ordering[Int].reverse)))
   }
@@ -39,7 +39,7 @@ class LogApplication @Inject()(cc: ControllerComponents) extends AbstractControl
   val MAX_NOTE_LENGTH : Int = 100
 
   def putSelfNote(airlineId : Int) = AuthenticatedAirline(airlineId) { request =>
-    val cycle = CycleSource.loadCycle
+    val cycle = CycleSource.loadCycle()
     val json = request.body.asInstanceOf[AnyContentAsJson].json
     json.\("note").asOpt[String] match {
       case Some(note) =>
@@ -58,8 +58,8 @@ class LogApplication @Inject()(cc: ControllerComponents) extends AbstractControl
     }
 
   }
-  
-  
 
-  
+
+
+
 }

--- a/airline-web/app/controllers/LogoUtil.scala
+++ b/airline-web/app/controllers/LogoUtil.scala
@@ -6,23 +6,23 @@ import com.patson.data.AirlineSource
 import javax.imageio.ImageIO
 
 object LogoUtil {
-  val logos : scala.collection.mutable.Map[Int, Array[Byte]] = collection.mutable.Map(AirlineSource.loadLogos().toSeq: _*) 
-  val blank = getBlankLogo
+  val logos : scala.collection.mutable.Map[Int, Array[Byte]] = collection.mutable.Map(AirlineSource.loadLogos().toSeq: _*)
+  val blank = getBlankLogo()
   val imageHeight = 12
   val imageWidth = 24
-  
+
   def getLogo(airlineId : Int) : Array[Byte]= {
     logos.get(airlineId) match {
       case Some(logo) => logo
       case None => blank
     }
   }
-  
+
   def saveLogo(airlineId : Int, logo : Array[Byte]) = {
     AirlineSource.saveLogo(airlineId, logo)
     logos.put(airlineId, logo) //update cache
   }
-  
+
   def validateUpload(logoFile : Path) : Option[String] = {
     val imageInputStream = ImageIO.createImageInputStream(logoFile.toFile)
     val readers = ImageIO.getImageReaders(imageInputStream)
@@ -41,7 +41,7 @@ object LogoUtil {
     }
     return None
   }
-  
+
   def getBlankLogo() = {
     //val buffer = new ByteArrayOutputStream();
     val is = play.Environment.simple().resourceAsStream("/logo/blank.png")

--- a/airline-web/app/controllers/NegotiationUtil.scala
+++ b/airline-web/app/controllers/NegotiationUtil.scala
@@ -415,7 +415,7 @@ object NegotiationUtil {
       return NegotiationUtil.NO_NEGOTIATION_REQUIRED.copy(remarks = Some(s"Free for first $FREE_LINK_THRESHOLD routes of freq <= $FREE_LINK_FREQUENCY_THRESHOLD (< $FREE_LINK_DIFFICULTY_THRESHOLD difficulty)"))
     }
 
-    val info = NegotiationInfo(fromAirportRequirements, toAirportRequirements, fromAirportDiscounts, toAirportDiscounts, totalFromDiscount, totalToDiscount, finalRequirementValue, computeOdds(finalRequirementValue, Math.min(MAX_ASSIGNED_DELEGATE, airline.getDelegateInfo.availableCount)))
+    val info = NegotiationInfo(fromAirportRequirements, toAirportRequirements, fromAirportDiscounts, toAirportDiscounts, totalFromDiscount, totalToDiscount, finalRequirementValue, computeOdds(finalRequirementValue, Math.min(MAX_ASSIGNED_DELEGATE, airline.getDelegateInfo().availableCount)))
     return info
   }
 
@@ -701,10 +701,3 @@ case class NegotiationLoyaltyBonusTemplate(bonusFactor : Int) extends Negotiatio
     NegotiationLoyaltyBonus(airport, loyaltyBonus.toDouble, duration, description, intensity)
   }
 }
-
-
-
-
-
-
-

--- a/airline-web/app/controllers/OlympicsApplication.scala
+++ b/airline-web/app/controllers/OlympicsApplication.scala
@@ -152,7 +152,7 @@ class OlympicsApplication @Inject()(cc: ControllerComponents) extends AbstractCo
       case None =>
     }
 
-    val currentCycle = CycleSource.loadCycle ()
+    val currentCycle = CycleSource.loadCycle()
     EventSource.loadEventById(eventId) match {
       case Some(olympics : Olympics) =>
 
@@ -416,5 +416,3 @@ class OlympicsApplication @Inject()(cc: ControllerComponents) extends AbstractCo
     }
   }
 }
-
-

--- a/airline-web/app/controllers/RankingUtil.scala
+++ b/airline-web/app/controllers/RankingUtil.scala
@@ -2,20 +2,20 @@ package controllers
 
 import com.patson.data.{AirlineSource, CycleSource, LinkSource, LoungeHistorySource}
 import com.patson.model._
- 
+
 
 object RankingUtil {
   var loadedCycle = 0
   var cachedRankings : Map[RankingType.Value, List[Ranking]] = Map.empty
-  
+
 //  val generatedLogo = ImageUtil.generateLogo("logo/star.bmp", Color.CYAN.getRGB, Color.RED.getRGB)
 //  LogoUtil.saveLogo(1, generatedLogo)
-  
+
   def getRankings() : Map[RankingType.Value, List[Ranking]] = {
     checkCache()
     cachedRankings
   }
-  
+
   private def checkCache() = {
     val currentCycle = CycleSource.loadCycle()
     synchronized {
@@ -27,13 +27,13 @@ object RankingUtil {
       loadedCycle = currentCycle
     }
   }
-  
+
   private[this] def updateRankings() = {
     val flightConsumptions = LinkSource.loadLinkConsumptions().filter(_.link.transportType == TransportType.FLIGHT)
     val flightConsumptionsByAirline = flightConsumptions.groupBy(_.link.airline.id)
     val links = LinkSource.loadAllFlightLinks().groupBy(_.airline.id)
     val airlinesById = AirlineSource.loadAllAirlines(fullLoad = true).map( airline => (airline.id, airline)).toMap
-    
+
     val updatedRankings = scala.collection.mutable.Map[RankingType.Value, List[Ranking]]()
     updatedRankings.put(RankingType.PASSENGER, getPassengerRanking(flightConsumptionsByAirline, airlinesById))
     updatedRankings.put(RankingType.PASSENGER_MILE, getPassengerMileRanking(flightConsumptionsByAirline, airlinesById))
@@ -41,7 +41,7 @@ object RankingUtil {
     updatedRankings.put(RankingType.SERVICE_QUALITY, getServiceQualityRanking(airlinesById))
     updatedRankings.put(RankingType.LINK_COUNT, getLinkCountRanking(links, airlinesById))
     updatedRankings.put(RankingType.LINK_PROFIT, getLinkProfitRanking(flightConsumptions, airlinesById))
-    updatedRankings.put(RankingType.LOUNGE, getLoungeRanking(LoungeHistorySource.loadAll, airlinesById))
+    updatedRankings.put(RankingType.LOUNGE, getLoungeRanking(LoungeHistorySource.loadAll(), airlinesById))
 
     val (paxByAirport, paxByAirportPair) = getPaxStat(flightConsumptions)
 
@@ -55,18 +55,18 @@ object RankingUtil {
 //    updatedRankings.put(RankingType.PASSENGER_EU, getPassengerByZoneRanking(linkConsumptionsByAirlineAndZone, airlinesById, RankingType.PASSENGER_EU, "EU"))
 //    updatedRankings.put(RankingType.PASSENGER_NA, getPassengerByZoneRanking(linkConsumptionsByAirlineAndZone, airlinesById, RankingType.PASSENGER_NA, "NA"))
 //    updatedRankings.put(RankingType.PASSENGER_SA, getPassengerByZoneRanking(linkConsumptionsByAirlineAndZone, airlinesById, RankingType.PASSENGER_SA, "SA"))
-    
-    
-    
+
+
+
     updateMovements(cachedRankings, updatedRankings.toMap)
-    
+
     cachedRankings = updatedRankings.toMap
   }
-  
+
   private[this] def getPassengerRanking(linkConsumptions : Map[Int, List[LinkConsumptionDetails]], airlinesById : Map[Int, Airline]) : List[Ranking] = {
     val passengersByAirline : Map[Int, Long] = linkConsumptions.view.mapValues(_.map(_.link.soldSeats.total.toLong).sum).toMap
     val sortedPassengersByAirline = passengersByAirline.toList.sortBy(_._2)(Ordering[Long].reverse)  //sort by total passengers of each airline
-    
+
     sortedPassengersByAirline.zipWithIndex.map {
       case((airlineId, passengers), index) => Ranking(RankingType.PASSENGER,
                                                       key = airlineId,
@@ -75,15 +75,15 @@ object RankingUtil {
                                                       rankedValue = passengers)
     }.toList.sortBy(_.ranking)
   }
-  
-  
+
+
   private[this] def getPassengerByZoneRanking(passengersByAirlineAndZone : Map[Int, Map[String, Long]], airlinesById : Map[Int, Airline], rankingType : RankingType.Value, zone : String) : List[Ranking] = {
     val passengersByAirline : Map[Int, Long] = passengersByAirlineAndZone.view.mapValues { passengersByZone =>
       passengersByZone.getOrElse(zone, 0L)
     }.toMap
 
     val sortedPassengersByAirline = passengersByAirline.toList.sortBy(_._2)(Ordering[Long].reverse)  //sort by total passengers of each airline
-    
+
     sortedPassengersByAirline.zipWithIndex.map {
       case((airlineId, passengers), index) => Ranking(rankingType,
                                                       key = airlineId,
@@ -92,24 +92,24 @@ object RankingUtil {
                                                       rankedValue = passengers)
     }.toList.sortBy(_.ranking)
   }
-  
+
   private[this] def getPassengersByZone(linkConsumptions : Map[Int, List[LinkConsumptionDetails]]) : Map[Int, Map[String, Long]] = {
     val passengersByAirlineAndZone : Map[Int, Map[String, Long]] = linkConsumptions.view.mapValues(_.groupBy(_.link.from.zone).view.mapValues { linkConsumptionsByZone =>
       linkConsumptionsByZone.map(_.link.soldSeats.total.toLong).sum
     }.toMap).toMap
-    
-    passengersByAirlineAndZone    
+
+    passengersByAirlineAndZone
   }
-  
-  
-  
+
+
+
   private[this] def getPassengerMileRanking(linkConsumptions : Map[Int, List[LinkConsumptionDetails]], airlinesById : Map[Int, Airline]) : List[Ranking] = {
     val passengerMileByAirline : Map[Int, Long] = linkConsumptions.view.mapValues(_.map { linkConsumption =>
         linkConsumption.link.soldSeats.total.toLong * linkConsumption.link.distance
       }.sum).toMap
-    
+
     val sortedPassengerMileByAirline= passengerMileByAirline.toList.sortBy(_._2)(Ordering[Long].reverse)  //sort by total passengers of each airline
-    
+
     sortedPassengerMileByAirline.zipWithIndex.map {
       case((airlineId, passengerMile), index) => Ranking(RankingType.PASSENGER_MILE,
                                                       key = airlineId,
@@ -118,10 +118,10 @@ object RankingUtil {
                                                       rankedValue = passengerMile)
     }.toList.sortBy(_.ranking)
   }
-  
+
   private[this] def getLinkProfitRanking(linkConsumptions : List[LinkConsumptionDetails], airlinesById : Map[Int, Airline]) : List[Ranking] = {
     val mostProfitableLinks : List[LinkConsumptionDetails] = linkConsumptions.sortBy(_.profit)(Ordering[Int].reverse)
-    
+
     mostProfitableLinks.zipWithIndex.map {
       case(linkConsumption, index) => {
         val airlineId = linkConsumption.link.airline.id
@@ -132,13 +132,13 @@ object RankingUtil {
                 rankedValue = linkConsumption.profit)
         ranking
       }
-                                           
+
     }.toList.sortBy(_.ranking).take(500)
   }
-  
+
   private[this] def getLoungeRanking(loungeConsumptions : List[LoungeConsumptionDetails], airlinesById : Map[Int, Airline]) : List[Ranking] = {
     val mostVisitedLounges : List[LoungeConsumptionDetails] = loungeConsumptions.sortBy(entry => entry.selfVisitors + entry.allianceVisitors)(Ordering[Int].reverse)
-    
+
     mostVisitedLounges.zipWithIndex.map {
       case(details, index) => {
         val lounge = details.lounge
@@ -149,15 +149,15 @@ object RankingUtil {
                 rankedValue = details.selfVisitors + details.allianceVisitors)
         ranking
       }
-                                           
+
     }.toList.sortBy(_.ranking)
   }
-  
-  
-  
+
+
+
   private[this] def getReputationRanking(airlinesById : Map[Int, Airline]) : List[Ranking] = {
     val airlinesBySortedReputation = airlinesById.values.toList.sortBy(_.getReputation())(Ordering[Double].reverse)
-    
+
     airlinesBySortedReputation.zipWithIndex.map {
       case(airline, index) =>  Ranking(RankingType.REPUTATION,
                                                       key = airline.id,
@@ -168,7 +168,7 @@ object RankingUtil {
   }
   private[this] def getServiceQualityRanking(airlinesById : Map[Int, Airline]) : List[Ranking] = {
     val airlinesBySortedServiceQuality = airlinesById.values.toList.sortBy(_.getCurrentServiceQuality())(Ordering[Double].reverse)
-    
+
     airlinesBySortedServiceQuality.zipWithIndex.map {
       case(airline, index) =>  Ranking(RankingType.SERVICE_QUALITY,
                                                       key = airline.id,
@@ -177,11 +177,11 @@ object RankingUtil {
                                                       rankedValue = airline.getCurrentServiceQuality())
     }
   }
-  
+
   private[this] def getLinkCountRanking(linksByAirline : Map[Int, List[Link]], airlinesById : Map[Int, Airline]) : List[Ranking] = {
     val linkCountByAirline : Map[Int, Int] = linksByAirline.view.mapValues(_.length).toMap
     val sortedLinkCountByAirline = linkCountByAirline.toList.sortBy(_._2)(Ordering[Int].reverse)  //sort by total passengers of each airline
-    
+
     sortedLinkCountByAirline.zipWithIndex.map {
       case((airlineId, linkCount), index) => Ranking(RankingType.LINK_COUNT,
                                                       key = airlineId,
@@ -190,7 +190,7 @@ object RankingUtil {
                                                       rankedValue = linkCount)
     }.toList
   }
-  
+
   private[this] def getAirportRanking(paxByAirport : Map[Airport, Long]) : List[Ranking] = {
     paxByAirport.toList.sortBy(_._2)(Ordering[Long].reverse).zipWithIndex.map {
       case((airport, passengers), index) => Ranking(RankingType.AIRPORT,
@@ -235,16 +235,16 @@ object RankingUtil {
     val previousRankingsByKey : Map[RankingType.Value, Map[Any, Int]] = previousRankings.view.mapValues { rankings =>
        rankings.map(ranking => (ranking.key, ranking.ranking)).toMap
     }.toMap
-    
-    
+
+
     newRankings.foreach {
       case(rankingType, rankings) =>  {
         val previousRankingOfThisType = previousRankingsByKey.get(rankingType)
         if (previousRankingOfThisType.isDefined) {
-           rankings.foreach { newRankingEntry => 
+           rankings.foreach { newRankingEntry =>
              val previousRanking = previousRankingOfThisType.get.get(newRankingEntry.key)
              if (previousRanking.isDefined) {
-               newRankingEntry.movement = newRankingEntry.ranking - previousRanking.get 
+               newRankingEntry.movement = newRankingEntry.ranking - previousRanking.get
              }
            }
         }
@@ -263,7 +263,5 @@ case class Ranking(rankingType : RankingType.Value, key : Any, entry : Any, rank
 
 
 //class AirlineRanking(rankingType : RankingType.Value, airline : Airline, ranking : Int, rankedValue : Number, var movement : Int = 0) extends Ranking(rankingType, airline, ranking, rankedValue, movement) {
-//  
+//
 //}
-
-

--- a/airline-web/app/controllers/SearchApplication.scala
+++ b/airline-web/app/controllers/SearchApplication.scala
@@ -200,7 +200,7 @@ class SearchApplication @Inject()(cc: ControllerComponents) extends AbstractCont
               detailedTransport.transportType match {
                 case TransportType.FLIGHT =>
                   val detailedLink = detailedTransport.asInstanceOf[Link]
-                  linkJson = linkJson + ("computedQuality" -> JsNumber(detailedLink.computedQuality))
+                  linkJson = linkJson + ("computedQuality" -> JsNumber(detailedLink.computedQuality()))
                   detailedLink.getAssignedModel().foreach { model =>
                     linkJson = linkJson + ("airplaneModelName" -> JsString(model.name))
                   }
@@ -278,7 +278,7 @@ class SearchApplication @Inject()(cc: ControllerComponents) extends AbstractCont
       if (result.isEmpty) {
         Ok(Json.obj("message" -> "No match"))
       } else {
-        Ok(Json.obj("entries" -> Json.toJson(result)(Writes.traversableWrites(new AirlineSearchResultWrites(input)))))
+        Ok(Json.obj("entries" -> Json.toJson(result)(Writes.iterableWrites(new AirlineSearchResultWrites(input)))))
       }
     }
   }
@@ -359,7 +359,7 @@ class SearchApplication @Inject()(cc: ControllerComponents) extends AbstractCont
     val features = ListBuffer[LinkFeature.Value]()
 
     import LinkFeature._
-    val airlineServiceQuality = link.airline.getCurrentServiceQuality
+    val airlineServiceQuality = link.airline.getCurrentServiceQuality()
     if (link.duration <= 120) { //very short flight
       if (link.rawQuality >= 80) {
         features += BEVERAGE_SERVICE
@@ -466,7 +466,7 @@ class SearchApplication @Inject()(cc: ControllerComponents) extends AbstractCont
 
 
 
-    result = result + ("consumptions" -> Json.toJson(consumptions)(Writes.traversableWrites(MinimumLinkConsumptionWrite)))
+    result = result + ("consumptions" -> Json.toJson(consumptions)(Writes.iterableWrites(MinimumLinkConsumptionWrite)))
     Ok(result)
   }
 
@@ -486,5 +486,3 @@ class SearchApplication @Inject()(cc: ControllerComponents) extends AbstractCont
   case class LinkDetail(link : Link, timeslot : TimeSlot)
 
 }
-
-

--- a/airline-web/app/controllers/package.scala
+++ b/airline-web/app/controllers/package.scala
@@ -41,8 +41,8 @@ package object controllers {
         "isGenerated" -> airline.isGenerated
       )
 
-      if (airline.getCountryCode.isDefined) {
-        result = result + ("countryCode" -> JsString(airline.getCountryCode.get))
+      if (airline.getCountryCode().isDefined) {
+        result = result + ("countryCode" -> JsString(airline.getCountryCode().get))
       }
       airline.getHeadQuarter().foreach { headquarters =>
         result = result +
@@ -182,7 +182,7 @@ package object controllers {
       link.setAssignedAirplanes(airplaneAssignments.toList.map {
         case(airplane, frequency) => (airplane, LinkAssignment(frequency, frequency * flightMinutesRequiredPerFlight))
       }.toMap)
-      //(json \ "id").asOpt[Int].foreach { link.id = _ } 
+      //(json \ "id").asOpt[Int].foreach { link.id = _ }
       JsSuccess(link)
     }
 
@@ -206,7 +206,7 @@ package object controllers {
       "flightType" -> JsString(FlightType.label(link.flightType)),
       "capacity" -> Json.toJson(link.capacity),
       "rawQuality" -> JsNumber(link.rawQuality),
-      "computedQuality" -> JsNumber(link.computedQuality),
+      "computedQuality" -> JsNumber(link.computedQuality()),
       "duration" -> JsNumber(link.duration),
       "frequency" -> JsNumber(link.frequency),
       "availableSeat" -> Json.toJson(link.availableSeats),
@@ -257,7 +257,7 @@ package object controllers {
         "capacity" -> Json.toJson(linkConsumption.link.capacity),
         "frequency" -> JsNumber(linkConsumption.link.frequency),
         "soldSeats" -> JsNumber(linkConsumption.link.soldSeats.total),
-        "quality" -> JsNumber(linkConsumption.link.computedQuality)))
+        "quality" -> JsNumber(linkConsumption.link.computedQuality())))
     }
   }
 
@@ -574,7 +574,7 @@ package object controllers {
         ))
 
         var bonusJson = Json.obj()
-        airport.getAllAirlineBonuses.toList.foreach {
+        airport.getAllAirlineBonuses().toList.foreach {
           case (airlineId, bonuses) => {
             var totalLoyaltyBonus = 0.0
             var loyaltyBreakdownJson = Json.arr(Json.obj("description" -> "Basic", "value" -> BigDecimal(airport.getAirlineBaseAppeal(airlineId).loyalty).setScale(2, RoundingMode.HALF_EVEN)))

--- a/airline-web/app/views/about.scala.html
+++ b/airline-web/app/views/about.scala.html
@@ -1,6 +1,4 @@
 @import helper._
-@import play.api.Play.current
-@import play.api.i18n.Messages.Implicits._
 <!DOCTYPE html>
 <html>
   <head>
@@ -10,7 +8,7 @@
       #map { height: 100%; }
     </style>
     <link rel="stylesheet" type="text/css" href="@routes.Assets.versioned("css-templates/treviso/css/style.css")">
-    
+
     <link rel="stylesheet" type="text/css" href="@routes.Assets.versioned("stylesheets/main.css")">
     <link rel="stylesheet" type="text/css" href="@routes.Assets.versioned("stylesheets/about.css")">
     <link rel="stylesheet" type="text/css" href="@routes.Assets.versioned("stylesheets/about-background.css")">
@@ -121,5 +119,5 @@
      })
 
 		</script>
-</body>    
+</body>
 </html>

--- a/airline-web/app/views/checkEmail.scala.html
+++ b/airline-web/app/views/checkEmail.scala.html
@@ -1,6 +1,4 @@
 @import helper._
-@import play.api.Play.current
-@import play.api.i18n.Messages.Implicits._
 <!DOCTYPE html>
 <html>
   <head>
@@ -10,7 +8,7 @@
       #map { height: 100%; }
     </style>
     <link rel="stylesheet" type="text/css" href="@routes.Assets.versioned("css-templates/treviso/css/style.css")">
-    
+
     <link rel="stylesheet" type="text/css" href="@routes.Assets.versioned("stylesheets/main.css")">
     <link rel="stylesheet" type="text/css" href="@routes.Assets.versioned("stylesheets/new-style.css")">
     <script src="@routes.Assets.versioned("javascripts/libs/jquery-2.1.4.js")"></script>
@@ -22,6 +20,6 @@
             <h1>Email sent!</h1>
             <div class="label">Help Instructions have been sent to the registered email address! Please make sure info@@airline-club.com is not blocked by your spam filter.</div>
         </div>
-	</div>        
-</body>    
+	</div>
+</body>
 </html>

--- a/airline-web/app/views/forgotId.scala.html
+++ b/airline-web/app/views/forgotId.scala.html
@@ -1,8 +1,6 @@
 @(forgotForm: Form[ForgotId])(implicit request: RequestHeader, messagesProvider: MessagesProvider)
 
 @import helper._
-@import play.api.Play.current
-@import play.api.i18n.Messages.Implicits._
 <!DOCTYPE html>
 <html>
   <head>
@@ -41,5 +39,5 @@
         </div>
 	</div>
     }
-</body>    
+</body>
 </html>

--- a/airline-web/app/views/forgotPassword.scala.html
+++ b/airline-web/app/views/forgotPassword.scala.html
@@ -1,8 +1,6 @@
 @(forgotForm: Form[ForgotPassword])(implicit request: RequestHeader, messagesProvider: MessagesProvider)
 
 @import helper._
-@import play.api.Play.current
-@import play.api.i18n.Messages.Implicits._
 <!DOCTYPE html>
 <html>
   <head>
@@ -12,7 +10,7 @@
       #map { height: 100%; }
     </style>
     <link rel="stylesheet" type="text/css" href="@routes.Assets.versioned("css-templates/treviso/css/style.css")">
-    
+
     <link rel="stylesheet" type="text/css" href="@routes.Assets.versioned("stylesheets/main.css")">
 	  <link rel="stylesheet" type="text/css" href="@routes.Assets.versioned("stylesheets/new-style.css")">
     <script src="@routes.Assets.versioned("javascripts/libs/jquery-2.1.4.js")"></script>
@@ -50,5 +48,5 @@
         </div>
 	</div>
     }
-</body>    
+</body>
 </html>

--- a/airline-web/app/views/signup.scala.html
+++ b/airline-web/app/views/signup.scala.html
@@ -1,8 +1,6 @@
 @(signupForm: Form[NewUser])(implicit request: RequestHeader, messagesProvider: MessagesProvider)
 
 @import helper._
-@import play.api.Play.current
-@import play.api.i18n.Messages.Implicits._
 <!DOCTYPE html>
 <html>
 <head>

--- a/airline-web/app/websocket/ActorCenter.scala
+++ b/airline-web/app/websocket/ActorCenter.scala
@@ -223,7 +223,7 @@ object ActorCenter {
   println("!!!!!!!!!!!!!!!AKK ACTOR HOST IS " + actorHost)
 
   val subscribers = mutable.HashSet[ActorRef]()
-  val remoteMainActor = system.actorSelection("akka.tcp://" + REMOTE_SYSTEM_NAME + "@" + actorHost + "/user/" + BRIDGE_ACTOR_NAME)
+  val remoteMainActor = system.actorSelection("akka://" + REMOTE_SYSTEM_NAME + "@" + actorHost + "/user/" + BRIDGE_ACTOR_NAME)
   val localMainActor = system.actorOf(Props(classOf[LocalMainActor], remoteMainActor), "local-main-actor")
 
 

--- a/airline-web/app/websocket/chat/ChatControllerActor.scala
+++ b/airline-web/app/websocket/chat/ChatControllerActor.scala
@@ -35,7 +35,7 @@ final case class PreviousMessagesResponse(previousMessages : List[ChatMessage])
 
 /**
  *  a single actor that handles when a ClientActor joins or leaves
- *  
+ *
  *  When a message is received from a ClientActor it would notify this actor, and this actor will send it out to all the corresponding subscribers (ClientActors)
  */
 
@@ -126,11 +126,11 @@ class ChatControllerActor extends Actor {
 
       val lastMessageIdOption = ChatSource.getLastChatId(user.id)
 
-      clientActors += sender
-      context.watch(sender)
+      clientActors += sender()
+      context.watch(sender())
       ChatControllerActor.addActiveUser(sender, user)
       //You can turn these loggers off if needed
-      logger.info("Chat socket connected " + sender + " for user " + user.userName + " current active sessions : " + clientActors.size + " unique users : " + ChatControllerActor.getActiveUsers().size)
+      logger.info("Chat socket connected " + sender() + " for user " + user.userName + " current active sessions : " + clientActors.size + " unique users : " + ChatControllerActor.getActiveUsers().size)
 
       // resend the Archived Message
       val allianceArchivedMessages =
@@ -146,13 +146,13 @@ class ChatControllerActor extends Actor {
 
       val generalMessageSource = if (user.isChatBanned) penaltyBoxMessageHistory else generalMessageHistory
       val sessionStart = getSessionStartMessage(generalMessageSource, allianceArchivedMessages, lastMessageIdOption)
-      sender ! sessionStart
+      sender() ! sessionStart
     }
 
 
 
     case PreviousMessagesRequest(airline, previousFirstMessageId, roomId) =>
-      sender ! buildPreviousMessagesResponse(airline, previousFirstMessageId, roomId)
+      sender() ! buildPreviousMessagesResponse(airline, previousFirstMessageId, roomId)
 
     //    case Leave => {
     //      context become process(subscribers - sender)

--- a/airline-web/build.sbt
+++ b/airline-web/build.sbt
@@ -4,14 +4,16 @@ version := "1.0-SNAPSHOT"
 
 lazy val root = (project in file(".")).enablePlugins(PlayScala)
 
-scalaVersion := "2.13.0"
+scalaVersion := "2.13.11"
 
 libraryDependencies ++= Seq(
   jdbc,
   ws,
   guice,
+  "com.google.inject" % "guice" % "5.1.0",
+  "com.google.inject.extensions" % "guice-assistedinject" % "5.1.0",
   specs2 % Test,
-  "com.typesafe.akka" %% "akka-remote" % "2.5.32",
+  "com.typesafe.akka" %% "akka-remote" % "2.6.21",
   "default" %% "airline-data" % "2.1",
   "com.google.api-client" % "google-api-client" % "1.30.4",
   "com.google.oauth-client" % "google-oauth-client-jetty" % "1.34.1",
@@ -23,9 +25,6 @@ libraryDependencies ++= Seq(
 
 // https://mvnrepository.com/artifact/org.elasticsearch.client/elasticsearch-rest-client
 libraryDependencies += "org.elasticsearch.client" % "elasticsearch-rest-high-level-client" % "7.17.2"
-
-
-
 
 resolvers += "scalaz-bintray" at "https://dl.bintray.com/scalaz/releases"
 

--- a/airline-web/conf/application.conf
+++ b/airline-web/conf/application.conf
@@ -43,17 +43,18 @@ play.i18n.langs = [ "en" ]
 # You can disable evolutions for a specific datasource if necessary
 # play.evolutions.db.default.enabled=false
 
+# Artery Reference: https://doc.akka.io/docs/akka/2.6/general/configuration-reference.html#config-akka-remote-artery
 akka {
   actor {
     provider = remote
   }
   remote {
-  	retry-gate-closed-for = 1000
-    enabled-transports = ["akka.remote.netty.tcp"]
-    netty.tcp {
-      hostname = "127.0.0.1"
-      port = 0
-      tcp-keepalive = on
+    artery {
+      transport = tcp
+      canonical {
+        hostname = "127.0.0.1"
+        port = 0
+      }
     }
   }
 }
@@ -64,6 +65,7 @@ my-pinned-dispatcher {
 }
 
 mysqldb.host="localhost:3306"
+
 airline.akka-actor.host="127.0.0.1:2552"
 google.apiKey="your-key-here"
 google.mapKey="your-key-here"

--- a/airline-web/project/build.properties
+++ b/airline-web/project/build.properties
@@ -1,4 +1,4 @@
 #Activator-generated Properties
 #Sun Nov 01 21:21:12 PST 2015
 template.uuid=fce2d244-c545-409f-806e-7a0c3681b306
-sbt.version=1.3.2
+sbt.version=1.9.9

--- a/airline-web/project/plugins.sbt
+++ b/airline-web/project/plugins.sbt
@@ -1,7 +1,10 @@
 // The Play plugin
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.7.3")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.22")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-less" % "1.1.2")
+
+// Resolves similar issue to https://stackoverflow.com/questions/76693403/scala-play-dependency-issue
+ThisBuild / libraryDependencySchemes += "org.scala-lang.modules" %% "scala-xml" % VersionScheme.Always
 
 // web plugins
 


### PR DESCRIPTION
### Why
Play 2.8.x is compatible with apple silicon, I had difficulties getting the older version setup.

### Categories of Changes
#### Dependency Upgrades
##### Bumped Akka to 2.6.21
[Official Migration Guide](https://doc.akka.io/docs/akka/2.6/project/migration-guide-2.5.x-2.6.x.html). Most notably default remoting is now 'Artery TCP'.  Some changes to application.conf otherwise you'll get some start-up issues with ports already in use (artery also changed the default port, but I overrode that back to what you were using).
##### Bumped Scala to 2.13.11
Fixed a lot of upcoming Scala 3 warnings, most notably calling a method without `()`.

#### Guice
Need to specify two Guice Specific libraryDependencies in `build.sbt` otherwise you'll get a cache exception.  These were recommended by Play when using JDK >= 17. (Lost the link, sorry)

#### Writes.traversableWrites is deprecated
[Official Docs](https://github.com/playframework/play-json/blob/main/play-json/shared/src/main/scala/play/api/libs/json/Writes.scala#L500) recommend `iterableWrites`

#### Play.current is deprecated
Removed usage from a few views.  Same for `play.api.i18n.Messages.Implicits._`


#### Styling
Sorry, my VSCode settings on code style ended up changing a lot before I noticed.

---
### Testing
Got airline-web and airline-data both running.  Did basic testing on airline-web (Create new user/airline, select base, setup some routes).  Let me know if you have an SOP for testing and I can do that in the future as well.