### PR TITLE
Play 3.0.x migration - cleaned

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ An opensource airline game.
 
 Live at https://www.airline-club.com/
 
-Version 2 alpha at https://v2.airline-club.com
+Version 2.1 released at https://v2.airline-club.com
 
 
 ![Screenshot 1](https://user-images.githubusercontent.com/2895902/74759887-5a966380-522e-11ea-9e54-2252af63d5ea.gif)

--- a/airline-web/app/controllers/AirportAssetApplication.scala
+++ b/airline-web/app/controllers/AirportAssetApplication.scala
@@ -142,7 +142,7 @@ class AirportAssetApplication @Inject()(cc: ControllerComponents) extends Abstra
 
   def getAirportAssetsWithAirline(airlineId : Int) = AuthenticatedAirline(airlineId) { request =>
     val assets = AirportAssetSource.loadAirportAssetsByAirline(airlineId)
-    Ok(Json.toJson(assets)(Writes.traversableWrites(OwnedAirportAssetWrites)))
+    Ok(Json.toJson(assets)(Writes.list(OwnedAirportAssetWrites)))
   }
 
   def getAirportAssetDetailsWithoutAirline(assetId : Int) = Action { request =>

--- a/airline-web/app/controllers/BankApplication.scala
+++ b/airline-web/app/controllers/BankApplication.scala
@@ -34,7 +34,7 @@ class BankApplication @Inject()(cc: ControllerComponents) extends AbstractContro
   )
 
   def viewLoans(airlineId : Int) = AuthenticatedAirline(airlineId) { request : AuthenticatedRequest[Any, Airline] =>
-    Ok(Json.toJson(BankSource.loadLoansByAirline(request.user.id))(Writes.traversableWrites(new LoanWrites(CycleSource.loadCycle()))))
+    Ok(Json.toJson(BankSource.loadLoansByAirline(request.user.id))(Writes.list(new LoanWrites(CycleSource.loadCycle()))))
   }
   
   def takeOutLoan(airlineId : Int) = AuthenticatedAirline(airlineId) { implicit request =>
@@ -64,7 +64,7 @@ class BankApplication @Inject()(cc: ControllerComponents) extends AbstractContro
     val loanReply = Bank.getMaxLoan(request.user.id)
     if (loanAmount <= loanReply.maxLoan) {
       val options = Bank.getLoanOptions(loanAmount)
-      Ok(Json.toJson(options)(Writes.traversableWrites(new LoanWrites(CycleSource.loadCycle()))))
+      Ok(Json.toJson(options)(Writes.list(new LoanWrites(CycleSource.loadCycle()))))
     } else {
       BadRequest("Borrowing [" + loanAmount + "] which is above limit [" + loanReply.maxLoan + "]")
     }

--- a/airline-web/app/controllers/ChatApplication.scala
+++ b/airline-web/app/controllers/ChatApplication.scala
@@ -1,8 +1,8 @@
 package controllers
 
 import javax.inject._
-import akka.actor._
-import akka.stream.Materializer
+import org.apache.pekko.actor._
+import org.apache.pekko.stream.Materializer
 import play.api._
 import play.api.mvc._
 

--- a/airline-web/app/controllers/SearchApplication.scala
+++ b/airline-web/app/controllers/SearchApplication.scala
@@ -278,7 +278,7 @@ class SearchApplication @Inject()(cc: ControllerComponents) extends AbstractCont
       if (result.isEmpty) {
         Ok(Json.obj("message" -> "No match"))
       } else {
-        Ok(Json.obj("entries" -> Json.toJson(result)(Writes.traversableWrites(new AirlineSearchResultWrites(input)))))
+        Ok(Json.obj("entries" -> Json.toJson(result)(Writes.list(new AirlineSearchResultWrites(input)))))
       }
     }
   }
@@ -466,7 +466,7 @@ class SearchApplication @Inject()(cc: ControllerComponents) extends AbstractCont
 
 
 
-    result = result + ("consumptions" -> Json.toJson(consumptions)(Writes.traversableWrites(MinimumLinkConsumptionWrite)))
+    result = result + ("consumptions" -> Json.toJson(consumptions)(Writes.list(MinimumLinkConsumptionWrite)))
     Ok(result)
   }
 
@@ -486,5 +486,3 @@ class SearchApplication @Inject()(cc: ControllerComponents) extends AbstractCont
   case class LinkDetail(link : Link, timeslot : TimeSlot)
 
 }
-
-

--- a/airline-web/app/controllers/package.scala
+++ b/airline-web/app/controllers/package.scala
@@ -1,5 +1,5 @@
-import akka.actor.ActorSystem
-import akka.stream.ActorMaterializer
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.stream.ActorMaterializer
 import com.patson.{AllianceMissionSimulation, Util}
 import com.patson.data._
 import com.patson.data.airplane._

--- a/airline-web/app/views/about.scala.html
+++ b/airline-web/app/views/about.scala.html
@@ -1,6 +1,4 @@
 @import helper._
-@import play.api.Play.current
-@import play.api.i18n.Messages.Implicits._
 <!DOCTYPE html>
 <html>
   <head>

--- a/airline-web/app/views/checkEmail.scala.html
+++ b/airline-web/app/views/checkEmail.scala.html
@@ -1,6 +1,4 @@
 @import helper._
-@import play.api.Play.current
-@import play.api.i18n.Messages.Implicits._
 <!DOCTYPE html>
 <html>
   <head>

--- a/airline-web/app/views/forgotId.scala.html
+++ b/airline-web/app/views/forgotId.scala.html
@@ -1,8 +1,6 @@
 @(forgotForm: Form[ForgotId])(implicit request: RequestHeader, messagesProvider: MessagesProvider)
 
 @import helper._
-@import play.api.Play.current
-@import play.api.i18n.Messages.Implicits._
 <!DOCTYPE html>
 <html>
   <head>

--- a/airline-web/app/views/forgotPassword.scala.html
+++ b/airline-web/app/views/forgotPassword.scala.html
@@ -1,8 +1,6 @@
 @(forgotForm: Form[ForgotPassword])(implicit request: RequestHeader, messagesProvider: MessagesProvider)
 
 @import helper._
-@import play.api.Play.current
-@import play.api.i18n.Messages.Implicits._
 <!DOCTYPE html>
 <html>
   <head>

--- a/airline-web/app/views/signup.scala.html
+++ b/airline-web/app/views/signup.scala.html
@@ -1,8 +1,6 @@
 @(signupForm: Form[NewUser])(implicit request: RequestHeader, messagesProvider: MessagesProvider)
 
 @import helper._
-@import play.api.Play.current
-@import play.api.i18n.Messages.Implicits._
 <!DOCTYPE html>
 <html>
 <head>

--- a/airline-web/app/websocket/ActorCenter.scala
+++ b/airline-web/app/websocket/ActorCenter.scala
@@ -1,7 +1,7 @@
 package websocket
 
-import akka.actor.{Actor, ActorRef, ActorSelection, Props, Terminated}
-import akka.remote.{AssociatedEvent, DisassociatedEvent, RemotingLifecycleEvent}
+import org.apache.pekko.actor.{Actor, ActorRef, ActorSelection, Props, Terminated}
+import org.apache.pekko.remote.{AssociatedEvent, DisassociatedEvent, RemotingLifecycleEvent}
 import com.patson.model.Airline
 import com.patson.model.notice.{AirlineNotice, NoticeCategory, TrackingNotice}
 import com.patson.stream.{CycleCompleted, CycleInfo, KeepAlivePing, KeepAlivePong, ReconnectPing, SimulationEvent}
@@ -219,11 +219,11 @@ object ActorCenter {
   implicit val system = actorSystem //ActorSystem("localWebsocketSystem")
 
   val configFactory = ConfigFactory.load()
-  val actorHost = if (configFactory.hasPath("airline.akka-actor.host")) configFactory.getString("airline.akka-actor.host") else "127.0.0.1:2552"
+  val actorHost = if (configFactory.hasPath("airline.pekko-actor.host")) configFactory.getString("airline.pekko-actor.host") else "127.0.0.1:2552"
   println("!!!!!!!!!!!!!!!AKK ACTOR HOST IS " + actorHost)
 
   val subscribers = mutable.HashSet[ActorRef]()
-  val remoteMainActor = system.actorSelection("akka.tcp://" + REMOTE_SYSTEM_NAME + "@" + actorHost + "/user/" + BRIDGE_ACTOR_NAME)
+  val remoteMainActor = system.actorSelection("pekko://" + REMOTE_SYSTEM_NAME + "@" + actorHost + "/user/" + BRIDGE_ACTOR_NAME)
   val localMainActor = system.actorOf(Props(classOf[LocalMainActor], remoteMainActor), "local-main-actor")
 
 

--- a/airline-web/app/websocket/Broadcaster.scala
+++ b/airline-web/app/websocket/Broadcaster.scala
@@ -1,7 +1,7 @@
 package websocket
 
-import akka.actor.ActorRef
-import akka.event.{EventBus, LookupClassification}
+import org.apache.pekko.actor.ActorRef
+import org.apache.pekko.event.{EventBus, LookupClassification}
 import com.patson.model.Airline
 import com.patson.util.AirlineCache
 import controllers.{PendingActionUtil, PromptUtil}

--- a/airline-web/app/websocket/MyWebsocketActor.scala
+++ b/airline-web/app/websocket/MyWebsocketActor.scala
@@ -1,8 +1,8 @@
 package websocket
 
 import java.util.concurrent.TimeUnit
-import akka.actor._
-import akka.util.Timeout
+import org.apache.pekko.actor._
+import org.apache.pekko.util.Timeout
 import com.patson.data.{CycleSource, UserSource}
 import com.patson.model.{UserModifier, UserStatus}
 import com.patson.model.notice.{AirlineNotice, LoyalistNotice, NoticeCategory}

--- a/airline-web/app/websocket/chat/ChatClientActor.scala
+++ b/airline-web/app/websocket/chat/ChatClientActor.scala
@@ -1,6 +1,6 @@
 package websocket.chat
 
-import akka.actor._
+import org.apache.pekko.actor._
 
 import java.util.Calendar
 import java.text.SimpleDateFormat

--- a/airline-web/app/websocket/chat/ChatControllerActor.scala
+++ b/airline-web/app/websocket/chat/ChatControllerActor.scala
@@ -3,8 +3,8 @@ package websocket.chat
 import java.time.Duration
 import java.util.concurrent.atomic.AtomicLong
 import java.util.concurrent.{ConcurrentHashMap, Executors, TimeUnit}
-import akka.actor._
-import akka.stream.ActorMaterializer
+import org.apache.pekko.actor._
+import org.apache.pekko.stream.ActorMaterializer
 import com.patson.data.{AllianceSource, ChatSource}
 import com.patson.model.chat.ChatMessage
 import com.patson.model.{Airline, AllianceRole, User}

--- a/airline-web/app/websocket/package.scala
+++ b/airline-web/app/websocket/package.scala
@@ -1,6 +1,6 @@
 
 
-import akka.actor.ActorSystem
+import org.apache.pekko.actor.ActorSystem
 
 import scala.concurrent.ExecutionContext
 package object websocket {

--- a/airline-web/build.sbt
+++ b/airline-web/build.sbt
@@ -4,14 +4,16 @@ version := "1.0-SNAPSHOT"
 
 lazy val root = (project in file(".")).enablePlugins(PlayScala)
 
-scalaVersion := "2.13.0"
+scalaVersion := "2.13.11"
 
 libraryDependencies ++= Seq(
   jdbc,
   ws,
   guice,
+  "com.google.inject" % "guice" % "5.1.0",
+  "com.google.inject.extensions" % "guice-assistedinject" % "5.1.0",
   specs2 % Test,
-  "com.typesafe.akka" %% "akka-remote" % "2.5.32",
+  "org.apache.pekko" %% "pekko-remote" % "1.0.3",
   "default" %% "airline-data" % "2.1",
   "com.google.api-client" % "google-api-client" % "1.30.4",
   "com.google.oauth-client" % "google-oauth-client-jetty" % "1.34.1",

--- a/airline-web/conf/application.conf
+++ b/airline-web/conf/application.conf
@@ -43,17 +43,18 @@ play.i18n.langs = [ "en" ]
 # You can disable evolutions for a specific datasource if necessary
 # play.evolutions.db.default.enabled=false
 
-akka {
+# Artery Reference: https://pekko.apache.org/docs/pekko/current/remoting-artery.html
+pekko {
   actor {
     provider = remote
   }
   remote {
-  	retry-gate-closed-for = 1000
-    enabled-transports = ["akka.remote.netty.tcp"]
-    netty.tcp {
-      hostname = "127.0.0.1"
-      port = 0
-      tcp-keepalive = on
+    artery {
+      transport = tcp
+      canonical {
+        hostname = "127.0.0.1"
+        port = 0
+      }
     }
   }
 }
@@ -64,7 +65,7 @@ my-pinned-dispatcher {
 }
 
 mysqldb.host="localhost:3306"
-airline.akka-actor.host="127.0.0.1:2552"
+airline.pekko-actor.host="127.0.0.1:2552"
 google.apiKey="your-key-here"
 google.mapKey="your-key-here"
 

--- a/airline-web/project/build.properties
+++ b/airline-web/project/build.properties
@@ -1,4 +1,4 @@
 #Activator-generated Properties
 #Sun Nov 01 21:21:12 PST 2015
 template.uuid=fce2d244-c545-409f-806e-7a0c3681b306
-sbt.version=1.3.2
+sbt.version=1.9.9

--- a/airline-web/project/plugins.sbt
+++ b/airline-web/project/plugins.sbt
@@ -1,7 +1,10 @@
 // The Play plugin
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.7.3")
+addSbtPlugin("org.playframework" % "sbt-plugin" % "3.0.5")
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-less" % "1.1.2")
+addSbtPlugin("com.github.sbt" % "sbt-less" % "2.0.1")
+
+// Resolves similar issue to https://stackoverflow.com/questions/76693403/scala-play-dependency-issue
+ThisBuild / libraryDependencySchemes += "org.scala-lang.modules" %% "scala-xml" % VersionScheme.Always
 
 // web plugins
 

--- a/airline-web/public/javascripts/alliance.js
+++ b/airline-web/public/javascripts/alliance.js
@@ -221,7 +221,13 @@ function loadAllAlliances(selectedAllianceId) {
 	    error: function(jqXHR, textStatus, errorThrown) {
 	            console.log(JSON.stringify(jqXHR));
 	            console.log("AJAX error: " + textStatus + ' : ' + errorThrown);
-	    }
+	    },
+        beforeSend: function() {
+            $('body .loadingSpinner').show()
+        },
+        complete: function(){
+            $('body .loadingSpinner').hide()
+        }
 	});
 }
 


### PR DESCRIPTION
Easiest on my end to just do a new PR, so closing https://github.com/patsonluk/airline/pull/618 in favor of this one. 
Removed all styling / changes not related to play 3.0.x migration.  

Compared to the PR, you will start to see warnings like this on startup:
`Auto-application to `()` is deprecated. Supply the empty argument list `()` explicitly to invoke method loadCycle,
[warn] or remove the empty argument list from its definition (Java-defined methods are exempt).
[warn] In Scala 3, an unapplied method like this will be eta-expanded into a function.
[warn]           val currentCycle = CycleSource.loadCycle
[warn]                                          ^
`

Note that I haven't done any performance testing, so can't speak to any degradation there.