### PR TITLE
Fix getYearMonthText incorrect months

### DIFF
--- a/airline-web/public/javascripts/gadgets.js
+++ b/airline-web/public/javascripts/gadgets.js
@@ -369,7 +369,7 @@ function getDurationText(duration) {
 
 function getYearMonthText(weekDuration) {
 	var year = Math.floor(weekDuration / 52)
-	var month = Math.floor(weekDuration / 4) % 12
+	var month = Math.floor(weekDuration / (52/12)) % 12
 	if (year > 0) {
 		return year + " year(s) " + month + " month(s)"
 	} else {


### PR DESCRIPTION
Months was essentially calculated off a 48 week year, or each month being exactly 4 weeks, which leads to the wrong output for airplane and fleet ages.

Under the old function:
51 weeks = 0 months
52 weeks = 1 year 1 months
479 weeks = 9 years 11 months
480 weeks = 9 years 0 months

With this fix:
51 weeks = 11 months
52 weeks = 1 year and 0 months
479 weeks = 9 years 2 months
480 weeks = 9 years 2 months