### PR TITLE
Airplane pricing/discount adjustments

### DIFF
--- a/airline-data/src/main/scala/com/patson/AirplaneModelSimulation.scala
+++ b/airline-data/src/main/scala/com/patson/AirplaneModelSimulation.scala
@@ -59,9 +59,9 @@ object AirplaneModelSimulation {
       case LIGHT => 300
       case SMALL => 300
       case REGIONAL => 500
-      case MEDIUM => 500
-      case LARGE => 500
-      case X_LARGE => 500
+      case MEDIUM => 1000
+      case LARGE => 1000
+      case X_LARGE => 750
       case JUMBO => 250
       case SUPERSONIC => 100
     }

--- a/airline-data/src/main/scala/com/patson/model/FlightPreference.scala
+++ b/airline-data/src/main/scala/com/patson/model/FlightPreference.scala
@@ -289,7 +289,7 @@ case class SpeedPreference(homeAirport : Airport, preferredLinkClass: LinkClass)
   override val loyaltySensitivity = 0
   override val frequencyThreshold = 14
   override val frequencySensitivity = 0.15
-  override val flightDurationSensitivity = 1.0
+  override val flightDurationSensitivity = 0.75
 
   def computeCost(baseCost : Double, link : Transport, linkClass : LinkClass) = {
     val noise = 0.9 + getFlatTopBellRandom(0.3, 0.25)


### PR DESCRIPTION
1. Category medium/large/extra large will have threshold up-adjusted. This is to counter a handful of models getting too popular and other models just have no ways to catch up (too many in circulations for discount). Adjusting those 3 groups as they are actually the ones with most airplanes in circulation in-game
2. Reduced speed preference pricing power due to speed from 100% to 75%. This is still the highest of all pax groups, but not too overpowered