### PR TITLE
Add airport pair index to link_consumption table

### DIFF
--- a/airline-data/db_scripts/patch_link_consumption_airport_pair_index.sql
+++ b/airline-data/db_scripts/patch_link_consumption_airport_pair_index.sql
@@ -1,0 +1,1 @@
+CREATE INDEX link_consumption_index_4 ON link_consumption(from_airport, to_airport);

--- a/airline-data/src/main/scala/com/patson/data/Constants.scala
+++ b/airline-data/src/main/scala/com/patson/data/Constants.scala
@@ -37,6 +37,7 @@ object Constants {
   val LINK_CONSUMPTION_INDEX_1 = "link_consumption_index_1"
   val LINK_CONSUMPTION_INDEX_2 = "link_consumption_index_2"
   val LINK_CONSUMPTION_INDEX_3 = "link_consumption_index_3"
+  val LINK_CONSUMPTION_INDEX_4 = "link_consumption_index_4"
   val LINK_ASSIGNMENT_TABLE = "link_assignment"
   val LINK_ASSIGNMENT_INDEX_1 = "link_assignment_index_1"
   val LINK_ASSIGNMENT_INDEX_2 = "link_assignment_index_2"

--- a/airline-data/src/main/scala/com/patson/data/Meta.scala
+++ b/airline-data/src/main/scala/com/patson/data/Meta.scala
@@ -453,6 +453,10 @@ object Meta {
     statement.execute()
     statement.close()
 
+    statement = connection.prepareStatement("CREATE INDEX " + LINK_CONSUMPTION_INDEX_4 + " ON " + LINK_CONSUMPTION_TABLE + "(from_airport, to_airport)")
+    statement.execute()
+    statement.close()
+
 
 //    statement = connection.prepareStatement("CREATE TABLE " + WATCHED_LINK_TABLE + "(" +
 //      "airline INTEGER PRIMARY KEY, " +


### PR DESCRIPTION
## Summary
- Adds composite index on `(from_airport, to_airport)` to the `link_consumption` table
- Speeds up the `loadLinkConsumptionsByAirportPair` query introduced in #661, which was slow due to missing index on those columns
- Includes migration script for existing databases

Fixes slow stacked bar chart loading in event view.

## Test plan
- [x] Verify event view stacked bar chart loads faster for airport pair history
- [x] Run migration script on existing database: `patch_link_consumption_airport_pair_index.sql`

🤖 Generated with [Claude Code](https://claude.com/claude-code)