### PR TITLE
Add log entry when lounge flips active/inactive

### DIFF
--- a/airline-data/src/main/scala/com/patson/AirportSimulation.scala
+++ b/airline-data/src/main/scala/com/patson/AirportSimulation.scala
@@ -37,7 +37,7 @@ object AirportSimulation {
     val championInfo = simulateLoyalists(allAirports, linkRidershipDetails, cycle)
 
     //check whether lounge is still active
-    updateLoungeStatus(allAirports, linkRidershipDetails)
+    updateLoungeStatus(allAirports, linkRidershipDetails, cycle)
 
 
     println("Finished simulation of loyalty by link consumption")
@@ -322,7 +322,7 @@ object AirportSimulation {
     result.toList.partition(_.amount > 0)
   }
 
-  def updateLoungeStatus(allAirports : List[Airport], linkRidershipDetails : Predef.Map[(PassengerGroup, Airport, Route), Int]) = {
+  def updateLoungeStatus(allAirports : List[Airport], linkRidershipDetails : Predef.Map[(PassengerGroup, Airport, Route), Int], cycle : Int) = {
     println("Checking lounge status")
     val passengersByAirport : MapView[Airport, MapView[Airline, Int]] = linkRidershipDetails.toList.flatMap {
       case ((passengerGroup, airport, route), count) =>
@@ -338,6 +338,7 @@ object AirportSimulation {
       }.groupBy(_._1).view.mapValues(_.map(_._2).sum)
     }
 
+    val logs = ListBuffer[Log]()
 
     allAirports.foreach { airport =>
       if (!airport.getLounges().isEmpty) {
@@ -359,10 +360,19 @@ object AirportSimulation {
           if (lounge.status != newStatus) {
             println(s"Flipping status for lounge $lounge to $newStatus")
             AirlineSource.saveLounge(lounge.copy(status = newStatus))
+            val severity = if (newStatus == LoungeStatus.ACTIVE) LogSeverity.INFO else LogSeverity.WARN
+            val message = if (newStatus == LoungeStatus.ACTIVE) {
+              s"Lounge at ${airport.displayText} is now ACTIVE"
+            } else {
+              s"Lounge at ${airport.displayText} is now INACTIVE"
+            }
+            logs += Log(lounge.airline, message, LogCategory.LOUNGE, severity, cycle)
           }
         }
       }
     }
+
+    LogSource.insertLogs(logs.toList)
   }
 //
 //  def airportProjectSimulation(allAirports : List[Airport]) = {

--- a/airline-data/src/main/scala/com/patson/model/Log.scala
+++ b/airline-data/src/main/scala/com/patson/model/Log.scala
@@ -8,13 +8,14 @@ object Log {
 
 object LogCategory extends Enumeration {
     type LogCategory = Value
-    val LINK, NEGOTIATION, AIRPORT_RANK_CHANGE, SELF_NOTE = Value
-    
+    val LINK, NEGOTIATION, AIRPORT_RANK_CHANGE, SELF_NOTE, LOUNGE = Value
+
     val getDescription : LogCategory.Value => String = {
       case LINK => "Flight Route"
       case NEGOTIATION => "Negotiation"
       case AIRPORT_RANK_CHANGE => "Airport Rank Change"
       case SELF_NOTE => "Self Note"
+      case LOUNGE => "Lounge"
     }
 }
 


### PR DESCRIPTION
## Summary

- Added `LOUNGE` to `LogCategory` (displayed as `"Lounge"` in the log tab)
- `AirportSimulation.updateLoungeStatus` now writes a log entry whenever a lounge flips status
- Goes **ACTIVE** → `INFO` severity; goes **INACTIVE** → `WARN` severity

Closes #664

🤖 Generated with [Claude Code](https://claude.com/claude-code)