### PR TITLE
Restrict airline usernames to admins

### DIFF
--- a/airline-web/app/controllers/AirlineApplication.scala
+++ b/airline-web/app/controllers/AirlineApplication.scala
@@ -50,14 +50,16 @@ class AirlineApplication @Inject()(cc: ControllerComponents) extends AbstractCon
     def writes(entry: (Airline, User, Option[LoginStatus.Value], Option[Alliance], List[AirlineModifier], List[(AirlineViolation.Value, Long)], Boolean)): JsValue = {
       val (airline, user, loginStatus, alliance, airlineModifiers, airlineViolations, isCurrentUserAdmin) = entry
       var result = Json.toJson(airline).asInstanceOf[JsObject] +
-        ("userLevel" -> JsNumber(user.level)) +
-        ("username" -> JsString(user.userName))
+        ("userLevel" -> JsNumber(user.level))
       user.adminStatus.foreach { adminStatus =>
         result = result + ("adminStatus" -> JsString(adminStatus.toString))
       }
 
       if (isCurrentUserAdmin) {
-        result = result + ("userStatus" -> JsString(user.status.toString)) + ("userId" -> JsNumber(user.id))
+        result = result +
+          ("username" -> JsString(user.userName)) +
+          ("userStatus" -> JsString(user.status.toString)) +
+          ("userId" -> JsNumber(user.id))
         result = result + ("userModifiers" -> Json.toJson(user.modifiers.map { case (m, ts) =>
           Json.obj("name" -> m.toString, "actionTimestamp" -> ts)
         }))

--- a/airline-web/public/javascripts/admin.js
+++ b/airline-web/public/javascripts/admin.js
@@ -92,7 +92,7 @@ function initAdminActions() {
 function showAdminActions(airline) {
     $("#rivalDetails .adminActions").data("userId", airline.userId)
     $("#rivalDetails .adminActions").data("airlineId", airline.id)
-    $("#rivalDetails .adminActions .username").text(airline.username)
+    $("#rivalDetails .adminActions .username").text(airline.username || '-')
     $("#rivalDetails .adminActions .userId").text(airline.userId)
 
     if (airline.userModifiers) {
@@ -167,7 +167,7 @@ function showAirlinesByIp(ip) {
                $row.append("<div class='cell'><input type='checkbox' checked='checked' data-user-id='" + entry.userId + "' data-airline-id='" + entry.airlineId + "'></div>")
                $row.append("<div class='cell clickable' onclick='loadRivalDetails(null," + entry.airlineId + "); closeModal($(\"#airlinesByUuidModal\"))'>" + getAirlineLogoImg(entry.airlineId) +  entry.airlineName + "</div>")
                $row.append("<div class='cell'>" + (entry.hqAirport ? getAirportText(entry.hqAirport.city, entry.hqAirport.iata) : "-") + "</div>")
-               $row.append("<div class='cell'>" + entry.username + getUserLevelImg(entry.userLevel) + "</div>")
+               $row.append("<div class='cell'>" + (entry.username || '-') + getUserLevelImg(entry.userLevel) + "</div>")
                $row.append("<div class='cell'>" + entry.userStatus + "</div>")
                $row.append("<div class='cell'>" + modifiersSpan + "</div>")
                $row.append("<div class='cell'>" + entry.lastUpdated + "</div>")
@@ -203,7 +203,7 @@ function showAirlinesByUuid(uuid) {
                 $row.append("<div class='cell'><input type='checkbox' checked='checked' data-user-id='" + entry.userId + "' data-airline-id='" + entry.airlineId + "'></div>")
                 $row.append("<div class='cell clickable' onclick='loadRivalDetails(null," + entry.airlineId + "); closeModal($(\"#airlinesByUuidModal\"))'>" + getAirlineLogoImg(entry.airlineId) +  entry.airlineName + "</div>")
                 $row.append("<div class='cell'>" + (entry.hqAirport ? getAirportText(entry.hqAirport.city, entry.hqAirport.iata) : "-") + "</div>")
-                $row.append("<div class='cell'>" + entry.username + getUserLevelImg(entry.userLevel) + "</div>")
+                $row.append("<div class='cell'>" + (entry.username || '-') + getUserLevelImg(entry.userLevel) + "</div>")
                 $row.append("<div class='cell'>" + entry.userStatus + "</div>")
                 $row.append("<div class='cell'>" + modifiersSpan + "</div>")
                 $row.append("<div class='cell'>" + entry.lastUpdated + "</div>")


### PR DESCRIPTION
Currently, /airlines shows the usernames of all airlines, which is probably unintended since usernames are never made public anywhere else

OpenAI Codex added a fallback when there is no username for the admin panel but it's not going to trigger anyways