### PR TITLE
Docker deployment + password-gated admin restart panel

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,16 @@
+.git
+.metals
+.vscode
+**/target
+**/project/target
+**/project/project
+airline-rest
+*.log
+*.iml
+airline-web/tokens
+airline-web/google-tokens
+airline-web/activator*
+airline-data/activator*
+sbt-launch.jar
+wt-*
+deploy/.env

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+deploy/.env

--- a/airline-data/build.sbt
+++ b/airline-data/build.sbt
@@ -4,6 +4,11 @@ version := "2.1"
 
 scalaVersion := "2.13.14"
 
+enablePlugins(JavaAppPackaging)
+
+// Many objects extend App; pin the launcher default. Other mains run via `bin/airline-data -main <class>`.
+Compile / mainClass := Some("com.patson.MainSimulation")
+
 libraryDependencies ++= Seq(
   "org.scalatest" %% "scalatest" % "3.0.8" % "test",
   "org.scala-lang.modules" %% "scala-parallel-collections" % "0.2.0",

--- a/airline-data/project/plugins.sbt
+++ b/airline-data/project/plugins.sbt
@@ -1,1 +1,2 @@
 //addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "4.0.0")
+addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.9.16")

--- a/airline-web/app/controllers/SearchUtil.java
+++ b/airline-web/app/controllers/SearchUtil.java
@@ -537,6 +537,13 @@ public class SearchUtil {
 
 
 	private static RestHighLevelClient getClient() {
+		com.typesafe.config.Config config = com.typesafe.config.ConfigFactory.load();
+		if (config.hasPath("elasticsearch.host")) {
+			int port = config.hasPath("elasticsearch.port") ? config.getInt("elasticsearch.port") : 9200;
+			return new RestHighLevelClient(
+					RestClient.builder(
+							new HttpHost(config.getString("elasticsearch.host"), port, "http")));
+		}
 		RestHighLevelClient client = new RestHighLevelClient(
 				RestClient.builder(
 						new HttpHost("localhost", 9200, "http"),

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -1,0 +1,38 @@
+# Copy this file to deploy/.env and fill the values.
+# deploy/.env is gitignored. Do not commit it.
+
+# --- MySQL ---
+DB_ROOT_PASSWORD=change-me
+DB_PASSWORD=change-me
+DB_USER=sa
+DB_SCHEMA=airline_v2_1
+
+# --- Play web server ---
+# Generate: openssl rand -hex 32
+SECRET_KEY=change-me
+
+# Optional Google keys. The map does not render without mapKey.
+GOOGLE_MAP_KEY=
+GOOGLE_API_KEY=
+
+# --- Heap sizes (all editable; restart the container to apply) ---
+# Budget for a 16 GB host: web ~1 GB, sim + ES take the rest.
+# Keep 1-2 GB free for MySQL, the panel, and the OS.
+SIM_HEAP=8g
+WEB_HEAP=1024m
+ES_HEAP=4g
+
+# false in production. When false, the sim purges inactive players (by design).
+# Set true on test stacks so test players are not purged.
+DEV_MODE=false
+
+# --- Ops panel ---
+# Generate the hash:
+#   python3 -c "from werkzeug.security import generate_password_hash; import getpass; print(generate_password_hash(getpass.getpass()))"
+# Or without a local python: after `docker compose build panel`:
+#   docker compose run --rm --entrypoint python3 panel -c "from werkzeug.security import generate_password_hash; import getpass; print(generate_password_hash(getpass.getpass()))"
+# IMPORTANT: put the hash in single quotes. The hash contains "$" characters,
+# and docker compose mangles unquoted "$" in .env values.
+PANEL_PASSWORD_HASH='change-me'
+# Generate: openssl rand -hex 32
+PANEL_SECRET_KEY=change-me

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -6,6 +6,10 @@ DB_ROOT_PASSWORD=change-me
 DB_PASSWORD=change-me
 DB_USER=sa
 DB_SCHEMA=airline_v2_1
+# Where sim and web find MySQL. Default db:3306 = the db container.
+# Hybrid mode (MySQL stays on the host, RUNBOOK section 12):
+#   DB_HOST=host.docker.internal:3306
+#DB_HOST=db:3306
 
 # --- Play web server ---
 # Generate: openssl rand -hex 32

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -1,0 +1,40 @@
+# syntax=docker/dockerfile:1
+# Build context is the repo root. Build with:
+#   docker build -f deploy/Dockerfile --target sim -t airline-sim .
+#   docker build -f deploy/Dockerfile --target web -t airline-web .
+
+# ---- builder ----
+# The image's pre-installed Scala (2.13.13) is irrelevant; sbt downloads the
+# project's own Scala 2.13.14. The tag matters for JDK 17 + sbt 1.9.9.
+FROM sbtscala/scala-sbt:eclipse-temurin-jammy-17.0.10_7_1.9.9_2.13.13 AS builder
+WORKDIR /build
+COPY airline-data /build/airline-data
+COPY airline-web  /build/airline-web
+# airline-web depends on airline-data as a published artifact ("default" %% "airline-data" % "2.1"),
+# so publishLocal must run before the web build. `stage` copies every dependency jar into
+# target/universal/stage/lib, so the runtime stages need nothing from the cache mounts.
+RUN --mount=type=cache,target=/root/.ivy2 \
+    --mount=type=cache,target=/root/.sbt \
+    --mount=type=cache,target=/root/.cache \
+    cd /build/airline-data && sbt -mem 2048 publishLocal stage && \
+    cd /build/airline-web  && sbt -mem 2048 stage
+
+# ---- sim runtime ----
+FROM eclipse-temurin:17-jre-jammy AS sim
+WORKDIR /app/airline-data
+COPY --from=builder /build/airline-data/target/universal/stage /app/airline-data
+# World-data files: the init/patcher mains read them relative to CWD (WORKDIR above).
+COPY airline-data/*.csv airline-data/*.txt /app/airline-data/
+COPY deploy/entrypoint-sim.sh /app/entrypoint-sim.sh
+RUN chmod +x /app/entrypoint-sim.sh
+ENTRYPOINT ["/app/entrypoint-sim.sh"]
+
+# ---- web runtime ----
+FROM eclipse-temurin:17-jre-jammy AS web
+RUN apt-get update && apt-get install -y --no-install-recommends curl && rm -rf /var/lib/apt/lists/*
+WORKDIR /app/airline-web
+COPY --from=builder /build/airline-web/target/universal/stage /app/airline-web
+COPY deploy/entrypoint-web.sh /app/entrypoint-web.sh
+RUN chmod +x /app/entrypoint-web.sh
+EXPOSE 9000
+ENTRYPOINT ["/app/entrypoint-web.sh"]

--- a/deploy/RUNBOOK.md
+++ b/deploy/RUNBOOK.md
@@ -1,0 +1,192 @@
+# Airline Club — Docker deployment runbook
+
+## Context
+
+*(This section is normal prose; the procedures below are STE.)*
+
+This runbook moves the game from a bare-metal install to Docker Compose on the same 16 GB GCP VM,
+and stands up a password-gated ops panel so admins can restart the game without SSH. Docker's only
+automatic behavior is restart-on-crash: a container whose process dies comes back by itself; a
+container stopped on purpose stays down. Nothing runs `MainInit` or patchers automatically — those
+remain deliberate command-line actions because `MainInit` drops every table.
+
+The stack: `db` (MySQL 5.7), `es` (Elasticsearch 7.17), `sim` (backend simulation), `web` (Play
+front end, port 9000), `panel` (ops panel, port 8080), and `socket-proxy` (limits the panel's Docker
+API access to container status/logs/start/stop/restart). The old bare-metal install stays intact
+until you decide to remove it, so rollback is always available.
+
+## 1. Install Docker on the VM
+
+1. Install Docker Engine and the compose plugin:
+   ```bash
+   curl -fsSL https://get.docker.com | sudo sh
+   ```
+2. Add your user to the docker group:
+   ```bash
+   sudo usermod -aG docker $USER
+   ```
+3. Log out and log in again.
+4. Make sure that Docker starts at boot:
+   ```bash
+   sudo systemctl enable docker
+   ```
+5. Check the installation:
+   ```bash
+   docker compose version
+   ```
+
+## 2. Get the code and set the configuration
+
+1. Clone the repository and check out the branch `deploy/docker`.
+2. Copy the environment template:
+   ```bash
+   cp deploy/.env.example deploy/.env
+   ```
+3. Open `deploy/.env` and set each value. The file has instructions for each key.
+4. Generate `SECRET_KEY` and `PANEL_SECRET_KEY`:
+   ```bash
+   openssl rand -hex 32
+   ```
+5. Generate `PANEL_PASSWORD_HASH` with the command shown in `deploy/.env.example`.
+
+Heap budget (16 GB VM): the web needs approximately 1 GB. The sim and Elasticsearch use the
+remainder. Keep 1 to 2 GB free for MySQL, the panel, and the OS. Swap use under load is expected.
+To change a heap size later: edit `SIM_HEAP`, `WEB_HEAP`, or `ES_HEAP` in `deploy/.env`, then run
+`docker compose -f deploy/docker-compose.yml up -d`. No image rebuild is necessary.
+
+## 3. Build the images
+
+1. Run:
+   ```bash
+   docker compose -f deploy/docker-compose.yml build
+   ```
+
+The first build downloads all sbt dependencies and can take 20 to 40 minutes. Later builds use the
+build cache and are much faster. If the VM is under memory pressure from the live game, build on a
+different machine and move the images with `docker save` and `docker load`.
+
+## 4. Import the production database
+
+Do the steps in this section for a migration of an existing install.
+
+1. On the old install, export the database:
+   ```bash
+   mysqldump --single-transaction --default-character-set=utf8mb4 -u sa -p airline_v2_1 > dump.sql
+   ```
+2. Start only the database container:
+   ```bash
+   docker compose -f deploy/docker-compose.yml up -d db
+   ```
+3. Wait until `docker ps` shows the db container as `healthy`.
+4. Import the dump:
+   ```bash
+   docker compose -f deploy/docker-compose.yml exec -T db sh -c 'mysql -usa -p"$MYSQL_PASSWORD" airline_v2_1' < dump.sql
+   ```
+
+## 5. Initialize a fresh database (dev only)
+
+**WARNING: `MainInit` drops all tables and deletes all game data. Do not run it against a
+database with player data. This procedure is for a fresh, empty install only. It is never
+automated; the dev runs it by hand.**
+
+1. Run the init main:
+   ```bash
+   docker compose -f deploy/docker-compose.yml run --rm sim -main com.patson.init.MainInit
+   ```
+2. After it completes, run the mandatory patcher:
+   ```bash
+   docker compose -f deploy/docker-compose.yml run --rm sim -main com.patson.patch.Version2_1Patcher
+   ```
+
+The patcher creates the tables `alliance_stats`, `alliance_mission`, and `airport_asset`. Without
+them, the alliance simulation fails on each cycle.
+
+## 6. First launch
+
+1. Start the full stack:
+   ```bash
+   docker compose -f deploy/docker-compose.yml up -d
+   ```
+2. Watch the sim log until it shows that the simulation runs:
+   ```bash
+   docker compose -f deploy/docker-compose.yml logs -f sim
+   ```
+3. Check the web front end:
+   ```bash
+   curl -fs http://localhost:9000/ > /dev/null && echo WEB_OK
+   ```
+
+## 7. Load the Elasticsearch index
+
+Do this once after the first launch, and again after a database import.
+
+**CAUTION: If Elasticsearch runs with an empty index, the alliance page returns errors on each
+cycle. Either load the index or stop the `es` container.**
+
+1. Run the index loader (approximately 4 minutes):
+   ```bash
+   docker compose -f deploy/docker-compose.yml run --rm web -main controllers.SearchUtil
+   ```
+2. Check the index:
+   ```bash
+   docker compose -f deploy/docker-compose.yml exec es curl -s 'localhost:9200/_cat/indices?v'
+   ```
+   Expected document counts: airports ≈ 3800, countries ≈ 233, zones 6, plus airlines and alliances.
+
+## 8. Ops panel
+
+1. Open `http://<vm-ip>:8080` in a browser.
+2. Log in with the admin password.
+3. The panel shows each container with its state and health.
+4. Use Restart, Stop, and Start on `sim`, `web`, and `es`.
+5. Use Logs to read the last 200 log lines of any container, `db` included.
+
+The panel cannot stop or restart `db`. A database problem is an escalation to the dev.
+
+Recommended hardening (optional, no TLS required): add a GCP firewall rule that limits TCP port
+8080 to admin IP addresses. Use a long random panel password.
+
+## 9. Cutover checklist
+
+1. Tell the players about the downtime.
+2. Stop the old sim process (the `MainSimulation` java process).
+3. Stop the old web process.
+4. Export the database (section 4, step 1).
+5. Import the database (section 4, steps 2 to 4).
+6. Start the stack (section 6).
+7. Load the Elasticsearch index (section 7).
+8. Smoke test: log in as a player, open the map, search for an airport.
+9. Watch the sim log until one full cycle completes.
+10. Point the firewall or DNS at port 9000.
+
+## 10. Rollback
+
+1. Stop the stack:
+   ```bash
+   docker compose -f deploy/docker-compose.yml down
+   ```
+2. Start the old bare-metal install (`airline-data/start.sh` and the old web start procedure).
+3. If players wrote data while Docker was live, export from the db container first and import
+   into the bare-metal MySQL.
+
+## 11. Operations reference
+
+- Read all logs: `docker compose -f deploy/docker-compose.yml logs -f <service>`.
+- After a VM reboot, the stack starts by itself (restart policy + Docker at boot).
+- A crashed container restarts by itself. A wedged-but-alive process does not; restart it from
+  the panel.
+- If live updates on the site stay stale after a sim restart, restart `web` from the panel.
+- Disk cleanup: `docker system prune` removes old images and build cache. It does not touch the
+  `dbdata` and `esdata` volumes.
+- **WARNING: `docker compose down -v` deletes the database volume. Do not use the `-v` flag.**
+
+## Known limits
+
+*(Normal prose.)*
+
+- Email password-reset and the Google Photos banner feature depend on token files
+  (`airline-web/tokens`, `google-tokens`) that are not baked into the images. If production uses
+  them, add a bind mount for those directories — confirm with the dev at cutover.
+- The panel has no TLS by design; the password travels in clear text on the network path. The GCP
+  firewall rule above is the compensating control.
+- MySQL 5.7 images are amd64-only; on an Apple-silicon dev machine the db container runs emulated.

--- a/deploy/RUNBOOK.md
+++ b/deploy/RUNBOOK.md
@@ -180,6 +180,35 @@ Recommended hardening (optional, no TLS required): add a GCP firewall rule that 
   `dbdata` and `esdata` volumes.
 - **WARNING: `docker compose down -v` deletes the database volume. Do not use the `-v` flag.**
 
+## 12. Hybrid mode: keep MySQL on the host
+
+Use this mode to containerize only the JVMs and Elasticsearch, with the existing bare-metal MySQL
+left in place. No data moves. This is a low-risk first step; move the database later or never.
+
+1. Make the host MySQL listen on the Docker bridge. In the MySQL config, set:
+   ```
+   bind-address = 0.0.0.0
+   ```
+   (Or bind to the docker0 address only. Keep the GCP firewall closed on port 3306.)
+2. Grant access from the Docker subnet:
+   ```sql
+   CREATE USER 'sa'@'172.%' IDENTIFIED BY '<the sa password>';
+   GRANT ALL PRIVILEGES ON airline_v2_1.* TO 'sa'@'172.%';
+   ```
+3. Restart the host MySQL.
+4. In `deploy/.env`, set:
+   ```
+   DB_HOST=host.docker.internal:3306
+   ```
+5. Start the stack without the db container:
+   ```bash
+   docker compose -f deploy/docker-compose.yml up -d --no-deps sim web es panel socket-proxy
+   ```
+
+`--no-deps` is necessary: without it, compose also starts the `db` container. The panel works the
+same in this mode; it does not list a db container, and database problems remain an escalation to
+the dev.
+
 ## Known limits
 
 *(Normal prose.)*

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -47,8 +47,12 @@ services:
       dockerfile: deploy/Dockerfile
       target: sim
     restart: unless-stopped
+    # Lets a container reach a MySQL that runs on the host itself
+    # (hybrid mode, RUNBOOK section 12). Harmless when unused.
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     environment:
-      DB_HOST: db:3306
+      DB_HOST: ${DB_HOST:-db:3306}
       DB_SCHEMA: ${DB_SCHEMA:-airline_v2_1}
       DB_USER: ${DB_USER:-sa}
       DB_PASSWORD: ${DB_PASSWORD:?}
@@ -75,8 +79,10 @@ services:
       - "9000:9000"
     # es and sim are not dependencies on purpose: the web starts without the
     # sim (ReconnectActor self-heals) and degrades without ES.
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     environment:
-      DB_HOST: db:3306
+      DB_HOST: ${DB_HOST:-db:3306}
       DB_SCHEMA: ${DB_SCHEMA:-airline_v2_1}
       DB_USER: ${DB_USER:-sa}
       DB_PASSWORD: ${DB_PASSWORD:?}

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -1,0 +1,142 @@
+name: airline
+
+# Restart policy note: `unless-stopped` restarts a container only when its
+# process dies. A container stopped on purpose (ops panel or `docker compose
+# stop`) stays down. Nothing in this file runs DB init or patchers.
+
+services:
+  db:
+    image: mysql:5.7.44
+    platform: linux/amd64
+    restart: unless-stopped
+    command: --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci
+    environment:
+      MYSQL_ROOT_PASSWORD: ${DB_ROOT_PASSWORD:?}
+      MYSQL_DATABASE: ${DB_SCHEMA:-airline_v2_1}
+      MYSQL_USER: ${DB_USER:-sa}
+      MYSQL_PASSWORD: ${DB_PASSWORD:?}
+    volumes:
+      - dbdata:/var/lib/mysql
+    healthcheck:
+      test: ["CMD-SHELL", "mysqladmin ping -h 127.0.0.1 -u$$MYSQL_USER -p$$MYSQL_PASSWORD --silent"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 60s
+
+  es:
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.17.22
+    restart: unless-stopped
+    environment:
+      - discovery.type=single-node
+      - xpack.security.enabled=false
+      - xpack.ml.enabled=false
+      - ES_JAVA_OPTS=-Xms${ES_HEAP:-4g} -Xmx${ES_HEAP:-4g}
+    volumes:
+      - esdata:/usr/share/elasticsearch/data
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fs 'http://localhost:9200/_cluster/health?wait_for_status=yellow&timeout=5s' || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 90s
+
+  sim:
+    build:
+      context: ..
+      dockerfile: deploy/Dockerfile
+      target: sim
+    restart: unless-stopped
+    environment:
+      DB_HOST: db:3306
+      DB_SCHEMA: ${DB_SCHEMA:-airline_v2_1}
+      DB_USER: ${DB_USER:-sa}
+      DB_PASSWORD: ${DB_PASSWORD:?}
+      SIM_HOST: sim
+      SIM_HEAP: ${SIM_HEAP:-8g}
+      DEV_MODE: ${DEV_MODE:-false}
+    depends_on:
+      db:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "bash", "-c", "exec 3<>/dev/tcp/127.0.0.1/2552"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 120s
+
+  web:
+    build:
+      context: ..
+      dockerfile: deploy/Dockerfile
+      target: web
+    restart: unless-stopped
+    ports:
+      - "9000:9000"
+    # es and sim are not dependencies on purpose: the web starts without the
+    # sim (ReconnectActor self-heals) and degrades without ES.
+    environment:
+      DB_HOST: db:3306
+      DB_SCHEMA: ${DB_SCHEMA:-airline_v2_1}
+      DB_USER: ${DB_USER:-sa}
+      DB_PASSWORD: ${DB_PASSWORD:?}
+      SIM_HOST: sim
+      WEB_HOST: web
+      WEB_HEAP: ${WEB_HEAP:-1024m}
+      ES_HOST: es
+      ES_PORT: 9200
+      SECRET_KEY: ${SECRET_KEY:?}
+      GOOGLE_MAP_KEY: ${GOOGLE_MAP_KEY:-}
+      GOOGLE_API_KEY: ${GOOGLE_API_KEY:-}
+    depends_on:
+      db:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-fs", "http://localhost:9000/"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 90s
+
+  socket-proxy:
+    image: tecnativa/docker-socket-proxy:0.3.0
+    restart: unless-stopped
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    environment:
+      CONTAINERS: 1
+      POST: 1
+      ALLOW_RESTARTS: 1
+      ALLOW_START: 1
+      ALLOW_STOP: 1
+    networks:
+      - ops
+
+  panel:
+    build: panel
+    restart: unless-stopped
+    ports:
+      - "8080:8080"
+    environment:
+      DOCKER_API: http://socket-proxy:2375
+      COMPOSE_PROJECT: airline
+      ALLOWED_SERVICES: sim,web,es
+      PANEL_PASSWORD_HASH: ${PANEL_PASSWORD_HASH:?}
+      PANEL_SECRET_KEY: ${PANEL_SECRET_KEY:?}
+    depends_on:
+      - socket-proxy
+    networks:
+      - ops
+      - default
+    healthcheck:
+      test: ["CMD", "python3", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8080/healthz', timeout=3)"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+
+networks:
+  ops: {}
+
+volumes:
+  dbdata: {}
+  esdata: {}

--- a/deploy/entrypoint-sim.sh
+++ b/deploy/entrypoint-sim.sh
@@ -5,6 +5,7 @@ set -eu
 # ConfigFactory.load() only; it does not read env vars itself.
 exec /app/airline-data/bin/airline-data \
   -J-Xms"${SIM_HEAP:-8g}" -J-Xmx"${SIM_HEAP:-8g}" \
+  -J-XX:+ExitOnOutOfMemoryError \
   -J-XX:MetaspaceSize=64m -J-XX:MaxMetaspaceSize=256m \
   -Dlog4j2.formatMsgNoLookups=true \
   -Dmysqldb.host="${DB_HOST:-db:3306}" \

--- a/deploy/entrypoint-sim.sh
+++ b/deploy/entrypoint-sim.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+set -eu
+
+# Map env vars to -D system properties. The game reads config through
+# ConfigFactory.load() only; it does not read env vars itself.
+exec /app/airline-data/bin/airline-data \
+  -J-Xms"${SIM_HEAP:-8g}" -J-Xmx"${SIM_HEAP:-8g}" \
+  -J-XX:MetaspaceSize=64m -J-XX:MaxMetaspaceSize=256m \
+  -Dlog4j2.formatMsgNoLookups=true \
+  -Dmysqldb.host="${DB_HOST:-db:3306}" \
+  -Dmysqldb.schema="${DB_SCHEMA:-airline_v2_1}" \
+  -Dmysqldb.user="${DB_USER:-sa}" \
+  -Dmysqldb.password="${DB_PASSWORD:?DB_PASSWORD is required}" \
+  -DwebsocketActorSystem.pekko.remote.artery.canonical.hostname="${SIM_HOST:-sim}" \
+  -DwebsocketActorSystem.pekko.remote.artery.canonical.port=2552 \
+  -Ddev="${DEV_MODE:-false}" \
+  "$@"

--- a/deploy/entrypoint-web.sh
+++ b/deploy/entrypoint-web.sh
@@ -3,8 +3,11 @@ set -eu
 
 # pidfile to /dev/null: a stale RUNNING_PID would otherwise block every
 # container restart and defeat restart-on-crash.
+# ExitOnOutOfMemoryError: an OutOfMemoryError otherwise wounds the JVM but
+# leaves it running, and the restart policy never fires on a zombie.
 exec /app/airline-web/bin/airline-web \
   -J-Xmx"${WEB_HEAP:-1024m}" \
+  -J-XX:+ExitOnOutOfMemoryError \
   -Dplay.server.pidfile.path=/dev/null \
   -Dhttp.address=0.0.0.0 \
   -Dhttp.port=9000 \

--- a/deploy/entrypoint-web.sh
+++ b/deploy/entrypoint-web.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+set -eu
+
+# pidfile to /dev/null: a stale RUNNING_PID would otherwise block every
+# container restart and defeat restart-on-crash.
+exec /app/airline-web/bin/airline-web \
+  -J-Xmx"${WEB_HEAP:-1024m}" \
+  -Dplay.server.pidfile.path=/dev/null \
+  -Dhttp.address=0.0.0.0 \
+  -Dhttp.port=9000 \
+  -Dplay.http.secret.key="${SECRET_KEY:?SECRET_KEY is required}" \
+  -Dmysqldb.host="${DB_HOST:-db:3306}" \
+  -Dmysqldb.schema="${DB_SCHEMA:-airline_v2_1}" \
+  -Dmysqldb.user="${DB_USER:-sa}" \
+  -Dmysqldb.password="${DB_PASSWORD:?DB_PASSWORD is required}" \
+  -Dsim.pekko-actor.host="${SIM_HOST:-sim}:2552" \
+  -DwebsocketActorSystem.pekko.remote.artery.canonical.hostname="${WEB_HOST:-web}" \
+  -DwebsocketActorSystem.pekko.remote.artery.canonical.port=10999 \
+  -DwebsocketActorSystem.pekko.remote.artery.bind.hostname=0.0.0.0 \
+  -DwebsocketActorSystem.pekko.remote.artery.bind.port=10999 \
+  -Delasticsearch.host="${ES_HOST:-es}" \
+  -Delasticsearch.port="${ES_PORT:-9200}" \
+  -Dgoogle.mapKey="${GOOGLE_MAP_KEY:-}" \
+  -Dgoogle.apiKey="${GOOGLE_API_KEY:-}" \
+  "$@"

--- a/deploy/panel/Dockerfile
+++ b/deploy/panel/Dockerfile
@@ -1,0 +1,9 @@
+FROM python:3.12-slim
+WORKDIR /panel
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY app.py .
+COPY templates templates
+USER nobody
+# Exactly 1 worker: the login rate limiter is in-process memory.
+CMD ["gunicorn", "-w", "1", "-b", "0.0.0.0:8080", "app:app"]

--- a/deploy/panel/app.py
+++ b/deploy/panel/app.py
@@ -1,0 +1,231 @@
+"""Airline Club ops panel.
+
+Password-gated control surface for the docker compose stack. Talks to the
+Docker Engine API only through the socket proxy (DOCKER_API), which limits
+the API surface to container list/inspect/logs/start/stop/restart.
+
+Run with exactly one gunicorn worker: sessions are signed cookies, but the
+login rate limiter is in-process memory.
+"""
+
+import json
+import os
+import struct
+import time
+from functools import wraps
+
+import requests
+from flask import (Flask, Response, abort, jsonify, redirect, render_template,
+                   request, session, url_for)
+from werkzeug.security import check_password_hash
+
+DOCKER_API = os.environ["DOCKER_API"].rstrip("/")
+COMPOSE_PROJECT = os.environ.get("COMPOSE_PROJECT", "airline")
+ALLOWED_SERVICES = [s.strip() for s in os.environ.get("ALLOWED_SERVICES", "sim,web,es").split(",") if s.strip()]
+PASSWORD_HASH = os.environ["PANEL_PASSWORD_HASH"]
+
+app = Flask(__name__)
+app.secret_key = os.environ["PANEL_SECRET_KEY"]
+app.config.update(SESSION_COOKIE_HTTPONLY=True, SESSION_COOKIE_SAMESITE="Lax")
+
+REQUEST_TIMEOUT = (3, 10)
+
+# --- login rate limiting (per source IP, in-process) ---
+FAIL_LIMIT = 5
+LOCK_BASE_SECONDS = 30
+LOCK_CAP_SECONDS = 15 * 60
+_failures = {}  # ip -> {"count": int, "locked_until": float}
+
+
+def _locked_for(ip):
+    entry = _failures.get(ip)
+    if not entry:
+        return 0
+    return max(0, entry["locked_until"] - time.time())
+
+
+def _record_failure(ip):
+    entry = _failures.setdefault(ip, {"count": 0, "locked_until": 0})
+    entry["count"] += 1
+    if entry["count"] >= FAIL_LIMIT:
+        lockouts = entry["count"] - FAIL_LIMIT
+        lock = min(LOCK_BASE_SECONDS * (2 ** lockouts), LOCK_CAP_SECONDS)
+        entry["locked_until"] = time.time() + lock
+
+
+def require_auth(fn):
+    @wraps(fn)
+    def wrapper(*args, **kwargs):
+        if not session.get("auth"):
+            if request.path.startswith("/api/"):
+                abort(401)
+            return redirect(url_for("login"))
+        return fn(*args, **kwargs)
+    return wrapper
+
+
+# --- Docker API helpers ---
+
+class DockerError(Exception):
+    def __init__(self, message, status=502):
+        super().__init__(message)
+        self.status = status
+
+
+def docker_get(path, params=None):
+    return _docker_call("GET", path, params=params)
+
+
+def docker_post(path, params=None):
+    return _docker_call("POST", path, params=params)
+
+
+def _docker_call(method, path, params=None):
+    try:
+        resp = requests.request(method, DOCKER_API + path, params=params, timeout=REQUEST_TIMEOUT)
+    except requests.RequestException as e:
+        raise DockerError("docker API unreachable: %s" % e.__class__.__name__)
+    if resp.status_code == 403:
+        raise DockerError("action not permitted by socket proxy", status=502)
+    if resp.status_code >= 400:
+        raise DockerError("docker API error %d: %s" % (resp.status_code, resp.text[:200]),
+                          status=502)
+    return resp
+
+
+@app.errorhandler(DockerError)
+def handle_docker_error(e):
+    return jsonify({"error": str(e)}), e.status
+
+
+def project_containers():
+    filters = json.dumps({"label": ["com.docker.compose.project=%s" % COMPOSE_PROJECT]})
+    resp = docker_get("/v1.41/containers/json", params={"all": "true", "filters": filters})
+    return resp.json()
+
+
+def find_container(service):
+    for c in project_containers():
+        if c.get("Labels", {}).get("com.docker.compose.service") == service:
+            return c
+    raise DockerError("no container found for service %r" % service, status=404)
+
+
+def demux_logs(raw):
+    """Strip the 8-byte frame headers of Docker's multiplexed log stream."""
+    out = []
+    i = 0
+    while i + 8 <= len(raw):
+        _stream, length = struct.unpack(">BxxxI", raw[i:i + 8])
+        out.append(raw[i + 8:i + 8 + length])
+        i += 8 + length
+    if not out:  # TTY container: stream is not multiplexed
+        return raw
+    return b"".join(out)
+
+
+# --- routes ---
+
+@app.route("/healthz")
+def healthz():
+    return "ok"
+
+
+@app.route("/login", methods=["GET", "POST"])
+def login():
+    ip = request.remote_addr or "?"
+    if request.method == "POST":
+        wait = _locked_for(ip)
+        if wait > 0:
+            return render_template("login.html", error="Too many attempts. Locked for %d seconds." % int(wait)), 429
+        if check_password_hash(PASSWORD_HASH, request.form.get("password", "")):
+            _failures.pop(ip, None)
+            session["auth"] = True
+            return redirect(url_for("index"))
+        _record_failure(ip)
+        return render_template("login.html", error="Wrong password."), 401
+    return render_template("login.html", error=None)
+
+
+@app.route("/logout")
+def logout():
+    session.clear()
+    return redirect(url_for("login"))
+
+
+@app.route("/")
+@require_auth
+def index():
+    return render_template("index.html", allowed=ALLOWED_SERVICES)
+
+
+@app.route("/api/status")
+@require_auth
+def api_status():
+    services = []
+    for c in project_containers():
+        labels = c.get("Labels", {})
+        service = labels.get("com.docker.compose.service", "?")
+        status_text = c.get("Status", "")  # e.g. "Up 3 hours (healthy)"
+        health = "none"
+        if "(healthy)" in status_text:
+            health = "healthy"
+        elif "(unhealthy)" in status_text:
+            health = "unhealthy"
+        elif "(health: starting)" in status_text:
+            health = "starting"
+        services.append({
+            "service": service,
+            "state": c.get("State", "?"),   # running / exited / ...
+            "status": status_text,
+            "health": health,
+            "image": c.get("Image", "?"),
+            "controllable": service in ALLOWED_SERVICES,
+        })
+    services.sort(key=lambda s: s["service"])
+    return jsonify({"services": services})
+
+
+def _act(service, verb, params=None):
+    if service not in ALLOWED_SERVICES:
+        abort(404)
+    container = find_container(service)
+    docker_post("/v1.41/containers/%s/%s" % (container["Id"], verb), params=params)
+    return jsonify({"ok": True, "service": service, "action": verb})
+
+
+@app.route("/api/service/<service>/restart", methods=["POST"])
+@require_auth
+def api_restart(service):
+    return _act(service, "restart", params={"t": 10})
+
+
+@app.route("/api/service/<service>/stop", methods=["POST"])
+@require_auth
+def api_stop(service):
+    # 30 s grace so a sim cycle can wind down before SIGKILL.
+    return _act(service, "stop", params={"t": 30})
+
+
+@app.route("/api/service/<service>/start", methods=["POST"])
+@require_auth
+def api_start(service):
+    return _act(service, "start")
+
+
+@app.route("/api/service/<service>/logs")
+@require_auth
+def api_logs(service):
+    # Logs are read-only: every project service is viewable, including db.
+    container = find_container(service)
+    tail = request.args.get("tail", "200")
+    if not tail.isdigit():
+        tail = "200"
+    resp = docker_get("/v1.41/containers/%s/logs" % container["Id"],
+                      params={"stdout": "1", "stderr": "1", "tail": tail, "timestamps": "1"})
+    text = demux_logs(resp.content).decode("utf-8", errors="replace")
+    return Response(text, mimetype="text/plain")
+
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=8080)

--- a/deploy/panel/requirements.txt
+++ b/deploy/panel/requirements.txt
@@ -1,0 +1,3 @@
+flask==3.0.3
+requests==2.32.3
+gunicorn==22.0.0

--- a/deploy/panel/templates/index.html
+++ b/deploy/panel/templates/index.html
@@ -1,0 +1,101 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Airline Club — Ops</title>
+<style>
+  :root { color-scheme: light dark; }
+  body { font-family: system-ui, sans-serif; margin: 0; padding: 1.5rem; }
+  header { display: flex; justify-content: space-between; align-items: baseline; }
+  h1 { font-size: 1.2rem; }
+  table { border-collapse: collapse; width: 100%; max-width: 60rem; }
+  th, td { text-align: left; padding: .5rem .75rem; border-bottom: 1px solid #8883; }
+  .state-running { color: #27ae60; font-weight: 600; }
+  .state-exited, .state-dead { color: #c0392b; font-weight: 600; }
+  .health-unhealthy { color: #e67e22; }
+  button { margin-right: .35rem; padding: .3rem .8rem; cursor: pointer; }
+  button:disabled { cursor: wait; opacity: .5; }
+  #logbox { margin-top: 1.5rem; max-width: 60rem; }
+  pre { background: #0002; padding: 1rem; overflow-x: auto; max-height: 24rem;
+        overflow-y: auto; font-size: .78rem; white-space: pre-wrap; }
+  .note { color: #888; font-size: .85rem; }
+  #err { color: #c0392b; min-height: 1.2rem; }
+</style>
+</head>
+<body>
+<header>
+  <h1>Airline Club ops panel</h1>
+  <a href="/logout">Log out</a>
+</header>
+<div id="err"></div>
+<table>
+  <thead><tr><th>Service</th><th>State</th><th>Status</th><th>Actions</th></tr></thead>
+  <tbody id="rows"><tr><td colspan="4">Loading…</td></tr></tbody>
+</table>
+<p class="note">Restart the sim first, then the web front end, if live updates stay stale.
+Database problems: contact the developer — do not restart <code>db</code> from here.</p>
+<div id="logbox" hidden>
+  <h2 id="logtitle" style="font-size:1rem"></h2>
+  <pre id="logs"></pre>
+</div>
+<script>
+const err = (m) => { document.getElementById('err').textContent = m || ''; };
+
+async function api(path, opts) {
+  const r = await fetch(path, opts);
+  if (r.status === 401) { location.href = '/login'; throw new Error('logged out'); }
+  if (!r.ok) {
+    let msg = 'HTTP ' + r.status;
+    try { msg = (await r.json()).error || msg; } catch (e) {}
+    throw new Error(msg);
+  }
+  return r;
+}
+
+async function refresh() {
+  try {
+    const data = await (await api('/api/status')).json();
+    const rows = data.services.map(s => {
+      const stateCls = 'state-' + s.state;
+      const healthCls = 'health-' + s.health;
+      const buttons = [];
+      if (s.controllable) {
+        buttons.push(`<button onclick="act('${s.service}','restart',this)">Restart</button>`);
+        if (s.state === 'running')
+          buttons.push(`<button onclick="act('${s.service}','stop',this)">Stop</button>`);
+        else
+          buttons.push(`<button onclick="act('${s.service}','start',this)">Start</button>`);
+      }
+      buttons.push(`<button onclick="showLogs('${s.service}')">Logs</button>`);
+      return `<tr><td>${s.service}</td><td class="${stateCls}">${s.state}</td>` +
+             `<td class="${healthCls}">${s.status}</td><td>${buttons.join('')}</td></tr>`;
+    });
+    document.getElementById('rows').innerHTML = rows.join('') || '<tr><td colspan="4">No containers found.</td></tr>';
+    err('');
+  } catch (e) { err('Status refresh failed: ' + e.message); }
+}
+
+async function act(service, verb, btn) {
+  if (!confirm(verb + ' ' + service + '?')) return;
+  btn.disabled = true;
+  try { await api(`/api/service/${service}/${verb}`, {method: 'POST'}); err(''); }
+  catch (e) { err(verb + ' ' + service + ' failed: ' + e.message); }
+  finally { btn.disabled = false; refresh(); }
+}
+
+async function showLogs(service) {
+  try {
+    const text = await (await api(`/api/service/${service}/logs?tail=200`)).text();
+    document.getElementById('logtitle').textContent = 'Logs: ' + service + ' (last 200 lines)';
+    document.getElementById('logs').textContent = text || '(empty)';
+    document.getElementById('logbox').hidden = false;
+    err('');
+  } catch (e) { err('logs failed: ' + e.message); }
+}
+
+refresh();
+setInterval(refresh, 5000);
+</script>
+</body>
+</html>

--- a/deploy/panel/templates/login.html
+++ b/deploy/panel/templates/login.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Airline Club — Ops</title>
+<style>
+  :root { color-scheme: light dark; }
+  body { font-family: system-ui, sans-serif; display: flex; min-height: 100vh;
+         align-items: center; justify-content: center; margin: 0; }
+  form { border: 1px solid #8884; border-radius: 8px; padding: 2rem; width: 20rem; }
+  h1 { font-size: 1.1rem; margin-top: 0; }
+  input[type=password] { width: 100%; padding: .5rem; margin: .5rem 0 1rem; box-sizing: border-box; }
+  button { padding: .5rem 1.5rem; cursor: pointer; }
+  .error { color: #c0392b; margin-top: 1rem; }
+</style>
+</head>
+<body>
+<form method="post" action="/login">
+  <h1>Airline Club ops panel</h1>
+  <label for="password">Admin password</label>
+  <input id="password" name="password" type="password" autofocus autocomplete="current-password">
+  <button type="submit">Log in</button>
+  {% if error %}<div class="error">{{ error }}</div>{% endif %}
+</form>
+</body>
+</html>


### PR DESCRIPTION
# Docker deployment + admin restart panel for airline-club

Addresses #680.

*Branch: `deploy/docker`, two commits, 13 new files + 3 edited files, +894 lines. Everything below was built and verified against a live local stack (fresh DB init, generated world, real logins, induced JVM crashes).*

## Disclosure

An AI model wrote this contribution. This section gives the facts.

- Anthropic's model "Claude Fable 5" generated 100% of the code in the two commits.
- The same model generated the text of this pull request and the related issue.
- A human operator set the goals, made the decisions, and approved the results.
- The model tested the changes only in the envelope that the section "What was verified, in one place" states.
- The changes have no tests against production data or production load.

## The problem this solves

The game currently runs as bare processes on a single VM, and only the person with SSH credentials can restart it when the sim or the web front end dies. This PR does two things:

1. Moves the whole install into Docker Compose, so a crashed process restarts itself.
2. Adds a small password-gated web panel (separate from airline-web, port 8080) from which non-dev admins can see container health, restart/stop/start the sim, the web front end, and Elasticsearch, and read the last N log lines of everything — no SSH, no TLS setup, no cloud credentials.

The old bare-metal way of running keeps working. Nothing about this is mandatory for existing installs.

## What actually changes in the codebase

Only two source-level changes; everything else is new files under `deploy/` plus `.dockerignore`/`.gitignore`.

**1. `airline-data` gets a packaging plugin** (3 lines: `sbt-native-packager` in `project/plugins.sbt`, `enablePlugins(JavaAppPackaging)` + `Compile / mainClass := Some("com.patson.MainSimulation")` in `build.sbt`). This makes `sbt stage` produce a plain runnable launcher, which is what the sim image runs. A side benefit: the launcher accepts `-main <class>`, so `MainInit`, `Version2_1Patcher`, and the ES indexer run as one-shots from the same image — no separate tooling. This changes nothing for people who run via `sbt run` / activator.

**2. `SearchUtil.java` reads the Elasticsearch host from config** when the key `elasticsearch.host` is set, and behaves exactly as before (hardcoded `localhost:9200` + `9201`) when it is not. Seven lines, no dependency added (`com.typesafe.config` is already on the classpath). This is the only hardcoded address in the codebase that config overrides could not reach.

Everything else the containers need — MySQL host/credentials, the Pekko remoting hostnames, heap sizes, the Play secret — was already reachable through `ConfigFactory.load()`, so the entrypoint scripts pass `-D` system properties at JVM start. **No `application.conf` is edited or forked.** Upstream can keep changing conf defaults without merge conflicts against this PR.

## Integration difficulty

Low. The honest list of things that needed figuring out, so you can judge for yourself:

- **The two actor systems must advertise resolvable names.** The web dials the sim at `sim.pekko-actor.host`, but the sim also dials *back* to the address the web's `websocketActorSystem` advertises — which is hardcoded `127.0.0.1:10999` in `airline-web/conf/application.conf`. In Docker, both canonical hostnames become the compose service names (`sim`, `web`) and the web's bind address widens to `0.0.0.0`, all via `-D` flags. This is the one piece of wiring that would genuinely bite anyone containerizing the game by hand.
- **`airline-web` depends on `airline-data` as a published artifact**, not a project reference, so the image build runs `publishLocal` before staging the web app. Handled inside one multi-stage Dockerfile; not visible to users.
- **The init mains read the CSV world data relative to the working directory.** The sim image carries the CSVs at its workdir, so `MainInit` and the patchers just work as one-shots.
- **Play writes a RUNNING_PID file** that blocks restart after a crash. The entrypoint sends it to `/dev/null`.

Merge risk to upstream code: the packaging plugin is additive; the SearchUtil change is behavior-preserving without the config key. Both compile cleanly (`sbt stage` in airline-data, `sbt compile` in airline-web, and full images were built and run).

## Failure modes after migrating, and what was done about each

For each: what could go wrong, and either the test that shows it doesn't, or the design that prevents it.

**Sim or web process dies (the current pain).**
`restart: unless-stopped` on every service. Tested by crashing the JVMs for real, not by `docker kill` (see caveat below): sent SIGSEGV to the sim's JVM — Docker's event stream shows the container `die` and a policy `start` 140 ms later — and SIGTERM to the web's. Both came back on their own, and the web came back with zero `RUNNING_PID` errors.

**After a sim restart, the web stops receiving cycle events.**
This was the biggest architectural worry: Pekko remoting can quarantine a peer after it restarts with the same address. It doesn't happen here because both sides address each other through `actorSelection` (fresh lookup) rather than persisted actor refs, and the web already has a `ReconnectActor` that re-subscribes on disassociation. Tested: after the SIGSEGV crash, the new sim incarnation logged a fresh subscription from `websocketActorSystem@web:10999` and resumed forwarding `CycleCompleted` to it. Worst case by code reading is the ReconnectActor's backoff cap (10 minutes of stale live-updates); the panel UI carries a hint ("restart web after sim if updates stay stale") for that case.

**An admin's deliberate Stop gets undone by the restart policy.**
It doesn't: `unless-stopped` distinguishes a process death (restarts) from a manual stop via the API (stays down). Verified both directions — an API kill left the container down until started; a real JVM crash auto-restarted.

**A wedged-but-alive JVM.**
This is the one crash class Docker does *not* auto-heal: plain compose does not restart a running-but-unhealthy container. Every service has a healthcheck, so the panel shows `unhealthy`, and the admin's Restart button is the remedy — which is still a large improvement over "wait for the dev". If it turns out to be frequent, a follow-up could add an autoheal sidecar; deliberately out of scope here.

**MySQL compatibility.**
Sidestepped entirely: the compose file pins `mysql:5.7.44` with `character_set_server=utf8mb4`, matching the current production setup and the `mysql-connector-java 5.1.49` already in the build. No driver upgrade, no MySQL 8 questions.

**Elasticsearch edge cases.**
ES is not a startup dependency of anything: the web starts without it and search degrades to empty results (existing behavior — every call path catches IOException). The known sharp edge is ES *reachable* with *empty indices*; the runbook makes index bootstrap an explicit step (`docker compose run --rm web -main controllers.SearchUtil`) and it was tested: 3819 airports, 233 countries indexed, search endpoint returning 200, no exceptions in the logs afterwards.

**Data loss.**
MySQL and ES data live in named volumes that survive `docker compose down`, image rebuilds, and VM reboots. The runbook warns explicitly against `down -v` (the one command that deletes volumes). The panel cannot touch the db container at all — restarting MySQL mid-sim-cycle is the kind of thing that corrupts a cycle, so db actions return 404 and db problems remain a dev escalation.

**Panel as an attack surface.**
The panel talks to Docker only through `tecnativa/docker-socket-proxy`, which is configured to allow exactly: list/inspect containers, read logs, start/stop/restart. Even a fully compromised panel cannot exec into containers, mount volumes, pull images, or read secrets through the Docker API. Login is a shared password (hash in `.env`, never plaintext), rate-limited with escalating lockouts — verified: 5 failures locks the source IP. There is deliberately no TLS (requirement was zero certificate/onboarding work); the compensating controls are a strong password and, optionally, a cloud firewall rule limiting port 8080 to admin IPs.

**What the panel is built on:** Python 3.12 + Flask behind gunicorn (single worker), talking plain HTTP to the Docker Engine API via the socket proxy. One ~230-line `app.py`, two HTML templates with vanilla JS (no frontend framework, no build step), three pinned dependencies (`flask`, `requests`, `gunicorn`). It ships as its own container off `python:3.12-slim` and runs as an unprivileged user. It shares nothing with airline-web — no Scala, no sbt, no game code — so it cannot break the game and the game cannot break it.

## How long a rollout takes

Downtime itself is not the concern here — the game already goes down for patches and players are used to it. The question is how big a maintenance window each variant needs and how much of the work happens before it.

- **Preparation (old game keeps running):** install Docker, clone, fill `.env`, build images. The first build compiles both sbt projects inside Docker and took ~13 minutes on a dev laptop; budget 15–45 minutes on a VM, or build elsewhere and `docker save | docker load`. All rehearsable and reversible.
- **JVM-only migration (hybrid mode, DB stays put):** a normal patch-sized window. Stop the old processes, `up -d` against the existing MySQL, smoke test. Minutes.
- **Full migration including the DB swap:** this is the genuinely bigger undertaking, and it should not be treated as a single stop-copy-start window. The sane shape is a parallel run: stand the containerized stack up next to the live game (different ports), import a dump, let it run cycles against the copy and verify behavior, then schedule the real cutover — stop old, final `mysqldump`, import, `up -d`, ES index bootstrap (~4 minutes on a fresh world; grows with data), smoke test. The final window is dominated by dump + import time; everything before it happens with the game live.

Rollback at any point: `docker compose down` (volumes intact), start the old bare-metal processes again. Nothing in the old setup is modified.

## The database question: containerize it, or leave it where it is?

Both are supported; the PR takes no side.

**Path A — containerized MySQL (the tested default).** Fresh `mysql:5.7.44` container, data imported via `mysqldump` from the old server into the container's volume. This was exercised end-to-end on this stack (schema init, imports, sim cycles, logins all against the containerized db). Upside: the whole game becomes one `docker compose up`; the VM needs no host MySQL at all. Downside: it is the bigger project — it moves the game's only state, so it deserves the parallel-run validation described above, and afterwards the db lives in a Docker volume the operator must not `-v` away.

**Path B — hybrid: containerize only the JVMs, leave MySQL untouched.** Fully supported, because every DB reference in both apps flows through one config key. Set `DB_HOST=host.docker.internal:3306` in `.env` (the compose file maps that name to the host on Linux), make the host MySQL listen on the Docker bridge and grant the `sa` user access from the Docker subnet, and start with `up -d --no-deps sim web es panel socket-proxy` so the db container never starts. Runbook section 12 has the exact steps. No data moves; a patch-sized window. Honesty note: this path was not run end-to-end here (the test machine has no host MySQL); mechanically it is identical to the tested path except for the hostname in the JDBC URL, but the MySQL `bind-address`/grant steps should be treated as the untested part.

A reasonable sequence is B first, then A later (or never).

## What was verified, in one place

On a scratch database, full stack on one machine: `MainInit` + `Version2_1Patcher` through the sim image; 250 generated airlines; player login through the real UI; web↔sim handshake over container DNS in both directions; sim SIGSEGV crash → auto-restart → automatic re-subscription and resumed cycle events; web SIGTERM crash → auto-restart, no pidfile block; panel login, rate-limit lockout, restart/stop through the socket proxy, db action refusal, demuxed log tailing; ES index bootstrap and working airport search.

**Not tested, stated plainly:** production-scale data volumes; multi-day stability under real load; the hybrid-DB host configuration end-to-end; the email password-reset and Google Photos banner features (their token files are not baked into images — if production uses them, they need a bind mount, flagged in the runbook).

## Files, for review order

- `deploy/RUNBOOK.md` — start here; it is the operator's view of everything above
- `deploy/docker-compose.yml` — topology, healthchecks, restart policies, socket-proxy permissions
- `deploy/Dockerfile`, `deploy/entrypoint-{sim,web}.sh` — build and env→`-D` wiring
- `deploy/panel/app.py` — the entire panel (~230 lines), plus two templates
- `airline-data/build.sbt`, `airline-data/project/plugins.sbt`, `airline-web/app/controllers/SearchUtil.java` — the only source changes
